### PR TITLE
Update dependencies

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -3,16 +3,36 @@ project(client DESCRIPTION "tagguys client executable")
 FetchContent_Declare(
   glew
   GIT_REPOSITORY https://github.com/Perlmint/glew-cmake
-  GIT_TAG master)
+  GIT_TAG glew-cmake-2.2.0)
 FetchContent_Declare(
   glfw
   GIT_REPOSITORY https://github.com/glfw/glfw.git
-  GIT_TAG master)
+  GIT_TAG 3.3.8)
 FetchContent_Declare(
   glm
   GIT_REPOSITORY https://github.com/g-truc/glm.git
-  GIT_TAG master)
-FetchContent_MakeAvailable(glew glfw glm)
+  GIT_TAG 0.9.9.8)
+FetchContent_Declare(
+  imgui
+  GIT_REPOSITORY https://github.com/yesean/imgui
+  GIT_TAG 46cacb7)
+FetchContent_Declare(
+  imgui
+  GIT_REPOSITORY https://github.com/yesean/imgui
+  GIT_TAG v1.0)
+FetchContent_Declare(
+  assimp
+  GIT_REPOSITORY https://github.com/assimp/assimp
+  GIT_TAG v5.2.5)
+FetchContent_MakeAvailable(glew glfw glm imgui assimp)
 
 add_executable(client ${PROJECT_SOURCE_DIR}/main.cpp)
-target_link_libraries(client PRIVATE core network libglew_static glfw glm)
+target_link_libraries(
+  client
+  PRIVATE core
+          network
+          libglew_static
+          glfw
+          glm
+          imgui
+          assimp)

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -3,7 +3,12 @@ project(
   DESCRIPTION
     "tagguys network library, includes: socket handling, message parsing, etc")
 
-find_package(Boost REQUIRED)
+FetchContent_Declare(
+  boost
+  GIT_REPOSITORY https://github.com/boostorg/boost
+  GIT_TAG boost-1.82.0)
+FetchContent_MakeAvailable(boost)
 
 add_library(network ${PROJECT_SOURCE_DIR}/lib.cpp)
 target_include_directories(network PUBLIC ${tagguys_SOURCE_DIR}/include)
+target_link_libraries(network PRIVATE Boost::asio)


### PR DESCRIPTION
This PR adds/update libraries for `client` and switches all dependency handling to FetchContent.
* adds `assimp`
* uses tags instead of `master` branch for library versioning
* switch `Boost` to FetchContent