### PR TITLE
Add config file support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_CXX_STANDARD 17)
 set(FETCHCONTENT_QUIET FALSE)
 
+add_subdirectory(src/config)
 add_subdirectory(src/core)
 add_subdirectory(src/network)
 add_subdirectory(src/client)

--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+  "server_address": "localhost",
+  "server_port": 2400
+}

--- a/include/config/lib.hpp
+++ b/include/config/lib.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+json get_config();

--- a/include/network/tcp_client.hpp
+++ b/include/network/tcp_client.hpp
@@ -11,7 +11,7 @@ using boost::asio::ip::tcp;
 
 struct Addr {
   std::string host;
-  std::string port;
+  int port;
 };
 
 class TCPClient {

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -73,6 +73,7 @@ target_link_libraries(
   client
   PRIVATE core
           network
+          config
           Boost::asio
           libglew_static
           glfw

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -1,6 +1,7 @@
 #include "client/graphics/main.h"
 
 #include <boost/asio.hpp>
+#include <config/lib.hpp>
 #include <iostream>
 #include <network/message.hpp>
 #include <network/tcp_client.hpp>
@@ -51,34 +52,11 @@ void print_versions() {
 }
 
 int main(int argc, char* argv[]) {
-  char* arg_host;
-  char* arg_port;
-
-  if (argc != 3) {
-    std::cout << "usage: client <host> <port>" << std::endl;
-
-    const unsigned int kMaxArgLength = 64;
-    char argbuff_1[kMaxArgLength];
-    char argbuff_2[kMaxArgLength];
-
-    std::cout << "enter <host>:";
-    std::cin.getline(argbuff_1, kMaxArgLength);
-
-    std::cout << "enter <port>:";
-    std::cin.getline(argbuff_2, kMaxArgLength);
-
-    arg_host = argbuff_1;
-    arg_port = argbuff_2;
-  } else {
-    arg_host = argv[1];
-    arg_port = argv[2];
-  }
-
-  std::cout << "connecting to: " << arg_host << ":" << arg_port << std::endl;
+  auto config = get_config();
 
   // NETWORK CODE
   boost::asio::io_context io_context;
-  Addr server_addr{arg_host, arg_port};
+  Addr server_addr{config["server_address"], config["server_port"]};
   auto connect_handler = [&](tcp::endpoint endpoint, TCPClient& client) {
     std::cout << "Connected to " << endpoint.address() << ":" << endpoint.port()
               << std::endl;

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -1,0 +1,15 @@
+project(client DESCRIPTION "tagguys config file manager")
+
+FetchContent_Declare(
+  json
+  GIT_REPOSITORY https://github.com/nlohmann/json
+  GIT_TAG v3.11.2
+  GIT_PROGRESS TRUE)
+FetchContent_MakeAvailable(json)
+
+add_library(config ${PROJECT_SOURCE_DIR}/lib.cpp)
+target_include_directories(config PUBLIC ${tagguys_SOURCE_DIR}/include)
+target_link_libraries(config PUBLIC nlohmann_json::nlohmann_json)
+
+configure_file(${CMAKE_SOURCE_DIR}/config.json
+               ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/config.json COPYONLY)

--- a/src/config/lib.cpp
+++ b/src/config/lib.cpp
@@ -1,0 +1,7 @@
+#include <config/lib.hpp>
+#include <fstream>
+
+json get_config() {
+  std::fstream f("config.json");
+  return json::parse(f);
+}

--- a/src/network/tcp_client.cpp
+++ b/src/network/tcp_client.cpp
@@ -10,7 +10,7 @@ TCPClient::TCPClient(boost::asio::io_context& io_context, Addr& addr,
   tcp::resolver resolver(io_context);
 
   boost::asio::async_connect(
-      socket_, resolver.resolve(addr.host, addr.port),
+      socket_, resolver.resolve(addr.host, std::to_string(addr.port)),
       [&, read_handler, write_handler, connect_handler](
           boost::system::error_code ec, tcp::endpoint endpoint) {
         if (ec) {

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -1,4 +1,4 @@
 project(server DESCRIPTION "tagguys server executable")
 
 add_executable(server ${PROJECT_SOURCE_DIR}/main.cpp)
-target_link_libraries(server PRIVATE core network Boost::asio)
+target_link_libraries(server PRIVATE core network config Boost::asio)

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -1,15 +1,13 @@
 #include <boost/asio.hpp>
+#include <config/lib.hpp>
 #include <iostream>
 #include <network/tcp_server.hpp>
 
 int main(int argc, char *argv[]) {
-  if (argc != 2) {
-    std::cout << "./server <port>" << std::endl;
-    return 1;
-  }
+  auto config = get_config();
 
   boost::asio::io_context io_context;
-  TCPServer server(io_context, std::stoi(argv[1]));
+  TCPServer server(io_context, config["server_port"]);
   io_context.run();
 
   return 0;


### PR DESCRIPTION
Resolves #23 

This PR adds support for configuring both `client` and `server` through a `config.json` file. JSON parsing is handled by [nlohmann/json](https://github.com/nlohmann/json).

The `config` library expects a `config.json` at the root of the repository which gets copied into the same directory as the `client` and `server` executables at build time. The exact schema of the config file doesn't need to be defined beforehand and can simply be used in code.

This PR adds basic usage by replacing the current CLI args with the config file in the client and server code.