### PR TITLE
Add game loop prototype

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,4 +1,5 @@
 filter=-legal/copyright
 filter=-build/include_order
+filter=-build/c++11
 filter=-runtime/references
 filter=-readability/todo

--- a/include/network/message.hpp
+++ b/include/network/message.hpp
@@ -17,6 +17,7 @@ enum class Type {
   Assign,
   Greeting,
   Notify,
+  GameStateUpdate,
 };
 
 struct Metadata {
@@ -56,10 +57,20 @@ struct Notify {
   }
 };
 
+struct GameStateUpdate {
+  std::string message;
+  std::string toString() { return message; }
+
+  template <typename Archive>
+  void serialize(Archive& ar, unsigned int) {
+    ar& message;
+  }
+};
+
 struct Message {
   Type type;
   Metadata metadata;
-  boost::variant<Assign, Greeting, Notify> body;
+  boost::variant<Assign, Greeting, Notify, GameStateUpdate> body;
 
   std::string toString() const;
   friend std::ostream& operator<<(std::ostream&, const Message&);

--- a/include/network/tcp_server.hpp
+++ b/include/network/tcp_server.hpp
@@ -26,5 +26,5 @@ class Server {
   void do_accept();
   void read(const PlayerID&);
   void write(const message::Message&, const PlayerID&);
-  void write_all(const message::Message&);
+  void write_all(message::Message&);
 };

--- a/include/network/tcp_server.hpp
+++ b/include/network/tcp_server.hpp
@@ -2,6 +2,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/container_hash/hash.hpp>
+#include <chrono>
 #include <memory>
 #include <network/connection.hpp>
 #include <network/message.hpp>
@@ -16,15 +17,18 @@ class Server {
   Server(boost::asio::io_context& io_context, int port);
 
  private:
-  friend std::ostream& operator<<(std::ostream&, Server*);
-
+  int update_num_ = 1;
+  std::chrono::milliseconds tick_rate_ = std::chrono::milliseconds(2000);
+  boost::asio::steady_timer timer_;
   tcp::acceptor acceptor_;
   std::unordered_map<PlayerID, std::unique_ptr<Connection<message::Message>>,
                      boost::hash<PlayerID>>
       connections_;
 
+  friend std::ostream& operator<<(std::ostream&, Server*);
   void do_accept();
   void read(const PlayerID&);
   void write(const message::Message&, const PlayerID&);
   void write_all(message::Message&);
+  void tick();
 };

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -66,11 +66,10 @@ void print_versions() {
 #endif
 }
 
-void network_init() {
+std::unique_ptr<Client> network_init(boost::asio::io_context& io_context) {
   auto config = get_config();
   Addr server_addr{config["server_address"], config["server_port"]};
 
-  boost::asio::io_context io_context;
   PlayerID player_id;
   auto connect_handler = [&](tcp::endpoint endpoint, Client& client) {
     std::cout << "(Client::connect) Connected to " << endpoint.address() << ":"
@@ -102,14 +101,14 @@ void network_init() {
               << ") Successfully wrote " << bytes_transferred
               << " bytes to server" << std::endl;
   };
-  Client client(io_context, server_addr, connect_handler, read_handler,
-                write_handler);
-  io_context.run_for(std::chrono::seconds(3));
+  auto client = std::make_unique<Client>(
+      io_context, server_addr, connect_handler, read_handler, write_handler);
+  return client;
 }
 
 int main(int argc, char* argv[]) {
-  network_init();
-  return 0;
+  boost::asio::io_context io_context;
+  auto client = network_init(io_context);
 
   // Create the GLFW window.
   GLFWwindow* window = Window::createWindow(800, 600);
@@ -148,6 +147,7 @@ int main(int argc, char* argv[]) {
     double deltaTime = nowTime - lastTime;
     lastTime = nowTime;
 
+    io_context.poll();
     // Idle callback. Updating objects, etc. can be done here.
     Window::idleCallback(window, deltaTime);
 

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -87,9 +87,13 @@ void network_init() {
     };
     auto greeting_handler = [&](const message::Greeting& body) {};
     auto notify_handler = [&](const message::Notify& body) {};
+    auto game_state_update_handler = [&](const message::GameStateUpdate& body) {
+    };
 
     auto message_handler = boost::make_overloaded_function(
-        assign_handler, greeting_handler, notify_handler);
+        assign_handler, greeting_handler, notify_handler,
+        game_state_update_handler);
+
     boost::apply_visitor(message_handler, m.body);
   };
   auto write_handler = [&](std::size_t bytes_transferred,

--- a/src/network/tcp_server.cpp
+++ b/src/network/tcp_server.cpp
@@ -64,9 +64,12 @@ void Server::do_accept() {
         write(new_m, player_id);
       };
       auto notify_handler = [&](const message::Notify& body) {};
+      auto game_state_update_handler =
+          [&](const message::GameStateUpdate& body) {};
 
       auto message_handler = boost::make_overloaded_function(
-          assign_handler, greeting_handler, notify_handler);
+          assign_handler, greeting_handler, notify_handler,
+          game_state_update_handler);
       boost::apply_visitor(message_handler, m.body);
 
       read(player_id);

--- a/src/network/tcp_server.cpp
+++ b/src/network/tcp_server.cpp
@@ -121,9 +121,12 @@ void Server::write(const message::Message& m, const PlayerID& id) {
   connections_[id]->write(m);
 }
 
-void Server::write_all(const message::Message& m) {
+void Server::write_all(message::Message& m) {
   // std::cout << "Queueing write to all clients: " << m << std::endl;
-  for (auto& kv : connections_) kv.second->write(m);
+  for (auto& kv : connections_) {
+    m.metadata.player_id = kv.first;
+    kv.second->write(m);
+  }
 }
 
 std::ostream& operator<<(std::ostream& os, Server* s) {


### PR DESCRIPTION
This PR adds a simple tick-based single threaded game loop.

At the moment, the server sends a game update to client every 2000ms, while the client polls for updates during every render loop cycle. The updating code on the server and client are both single-threaded, which doesn't seem to affect performance, since of the expensive io operations are async.