### PR TITLE
API improvments, code cleanup

### DIFF
--- a/include/client/graphics/Player.h
+++ b/include/client/graphics/Player.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <utility>
+
 #include "Camera.h"
 #include "GameThing.h"
 #include "InputListener.h"
@@ -34,7 +36,7 @@ class Player : public GameThing, InputListener {
   }
 
   UserState update(float dt);
-  glm::vec3 move(glm::vec3 movement);  // NOLINT
+  glm::vec3 move(glm::vec3 movement);
 
   void faceDirection(glm::vec3 direction);
 };

--- a/include/network/connection.hpp
+++ b/include/network/connection.hpp
@@ -106,9 +106,11 @@ void Connection<T>::read() {
   // read header
   boost::asio::async_read(
       socket_, boost::asio::buffer(inbound_header_),
-      [&](boost::system::error_code header_ec, std::size_t header_bytes_read) {
-        if (header_ec) {
-          return read_handler(header_ec, T());
+      [&](boost::system::error_code ec, std::size_t header_bytes_read) {
+        if (ec) {
+          std::cerr << "(Connection::read) Error reading header: "
+                    << ec.message() << std::endl;
+          return read_handler(ec, T());
         }
 
         try {
@@ -116,17 +118,24 @@ void Connection<T>::read() {
           inbound_data_.resize(inbound_data_size);
 
           // read message
-          boost::system::error_code message_ec;
+          boost::system::error_code ec;
           std::size_t message_bytes_read = boost::asio::read(
-              socket_, boost::asio::buffer(inbound_data_), message_ec);
-          if (message_ec) {
-            return read_handler(message_ec, T());
+              socket_, boost::asio::buffer(inbound_data_), ec);
+          if (ec) {
+            std::cerr << "(Connection::read) Error reading data: "
+                      << ec.message() << std::endl;
+            return read_handler(ec, T());
           }
 
           T t = parse_data();
-          read_handler(message_ec, t);
-        } catch (const boost::system::error_code& e) {
-          read_handler(e, T());
+          std::cout << "(Connection::read) Received ("
+                    << inbound_data_size + header_length_ << " bytes)\n"
+                    << t << std::endl;
+          read_handler(ec, t);
+        } catch (const boost::system::error_code& ec) {
+          std::cerr << "(Connection::read) Error parsing data: " << ec.message()
+                    << std::endl;
+          return read_handler(ec, T());
         }
       });
 }
@@ -138,6 +147,8 @@ void Connection<T>::write(const T& data) {
     std::string outbound_header = build_header(outbound_data);
     outbound_payloads_.push_back({outbound_header, outbound_data});
   } catch (const boost::system::error_code& ec) {
+    std::cerr << "(Connection::write) Error serializing data: " << ec.message()
+              << std::endl;
     return write_handler(ec, 0, data);
   }
 
@@ -148,6 +159,15 @@ void Connection<T>::write(const T& data) {
       socket_, buffers,
       [&, data](boost::system::error_code ec, std::size_t length) {
         outbound_payloads_.pop_front();
+
+        if (ec) {
+          std::cerr << "(Connection::write) Error writing data: "
+                    << ec.message() << std::endl;
+          return write_handler(ec, 0, data);
+        }
+
+        std::cout << "(Connection::write) Successfully wrote " << length
+                  << " bytes" << std::endl;
         write_handler(ec, length, data);
       });
 }

--- a/include/network/message.hpp
+++ b/include/network/message.hpp
@@ -28,10 +28,15 @@ struct Metadata {
 };
 
 struct Assign {
-  std::string toString() { return "assign response"; }
+  PlayerID player_id;
+  std::string toString() {
+    return "assigning player_id: " + boost::uuids::to_string(player_id);
+  }
 
   template <typename Archive>
-  void serialize(Archive& ar, unsigned int) {}
+  void serialize(Archive& ar, unsigned int) {
+    ar& player_id;
+  }
 };
 
 struct Greeting {

--- a/include/network/message.hpp
+++ b/include/network/message.hpp
@@ -152,10 +152,12 @@ struct UserStateUpdate {
 };
 
 struct Message {
+  using Body = boost::variant<Assign, Greeting, Notify, GameStateUpdate,
+                              UserStateUpdate>;
+
   Type type;
   Metadata metadata;
-  boost::variant<Assign, Greeting, Notify, GameStateUpdate, UserStateUpdate>
-      body;
+  Body body;
 
   std::string toString() const;
   friend std::ostream& operator<<(std::ostream&, const Message&);
@@ -166,4 +168,5 @@ struct Message {
   }
 };
 
+Type get_type(const Message::Body&);
 }  // namespace message

--- a/include/network/message.hpp
+++ b/include/network/message.hpp
@@ -29,9 +29,7 @@ struct Metadata {
 
 struct Assign {
   PlayerID player_id;
-  std::string toString() {
-    return "assigning player_id: " + boost::uuids::to_string(player_id);
-  }
+  std::string to_string() const;
 
   template <typename Archive>
   void serialize(Archive& ar, unsigned int) {
@@ -41,7 +39,7 @@ struct Assign {
 
 struct Greeting {
   std::string greeting;
-  std::string toString() { return greeting; }
+  std::string to_string() const;
 
   template <typename Archive>
   void serialize(Archive& ar, unsigned int) {
@@ -51,7 +49,7 @@ struct Greeting {
 
 struct Notify {
   std::string message;
-  std::string toString() { return message; }
+  std::string to_string() const;
 
   template <typename Archive>
   void serialize(Archive& ar, unsigned int) {
@@ -66,26 +64,7 @@ struct GameStateUpdateItem {
   float posy;
   float posz;
   float heading;
-
-  GameStateUpdateItem() {}
-
-  std::string toString() {
-    // clang-format off
-    std::string str = std::string("") + "{\n" +
-                      "  id: " + std::to_string(id) +
-                      ",\n" +  // NOLINT
-                      "  position: {\n" +
-                      "  " + std::to_string(posx) +
-                      ", " + std::to_string(posy) +
-                      ", " + std::to_string(posz) +
-                      "\n" +  // NOLINT
-                      "  },\n" +
-                      "  heading: " + std::to_string(heading) +
-                      ",\n" +  // NOLINT
-                      "}";
-    // clang-format on
-    return str;
-  }
+  std::string to_string() const;
 
   template <typename Archive>
   void serialize(Archive& ar, unsigned int) {
@@ -100,23 +79,14 @@ struct GameStateUpdateItem {
 struct GameStateUpdate {
   std::vector<GameStateUpdateItem*> things;
   // add global params later
-
-  std::string toString() {
-    // clang-format off
-    std::string str = std::string("") + "{\n" +
-                      "items:\n";
-    // clang-format on
-    for (auto i : things) {
-      str += i->toString();
-    }
-    return str;
-  }
+  std::string to_string() const;
 
   template <typename Archive>
   void serialize(Archive& ar, unsigned int) {
     ar& things;
   }
 };
+
 struct UserStateUpdate {
   int id;
   float movx;
@@ -124,26 +94,7 @@ struct UserStateUpdate {
   float movz;
   bool jump;
   float heading;
-
-  std::string toString() {
-    // clang-format off
-    std::string str = std::string("") + "{\n" +
-                      "  id: " + std::to_string(id) +
-                      ",\n" +  // NOLINT
-                      "  movement delta: {\n" +
-                      "  " + std::to_string(movx) +
-                      ", " + std::to_string(movy) +
-                      ", " + std::to_string(movz) +
-                      "\n" +  // NOLINT
-                      "  },\n" +
-                      "  jump: " + std::to_string(jump) +
-                      ",\n" +  // NOLINT
-                      "  heading: " + std::to_string(heading) +
-                      ",\n" +  // NOLINT
-                      "}";
-    // clang-format on
-    return str;
-  }
+  std::string to_string() const;
 
   template <typename Archive>
   void serialize(Archive& ar, unsigned int) {
@@ -159,12 +110,10 @@ struct UserStateUpdate {
 struct Message {
   using Body = boost::variant<Assign, Greeting, Notify, GameStateUpdate,
                               UserStateUpdate>;
-
   Type type;
   Metadata metadata;
   Body body;
-
-  std::string toString() const;
+  std::string to_string() const;
   friend std::ostream& operator<<(std::ostream&, const Message&);
 
   template <typename Archive>
@@ -174,4 +123,5 @@ struct Message {
 };
 
 Type get_type(const Message::Body&);
+
 }  // namespace message

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -89,17 +89,13 @@ std::unique_ptr<Client> network_init(boost::asio::io_context& io_context) {
       // Window::gameScene->initFromServer(myId); // need a unique int id
       client.write<message::Greeting>("Hello, server!");
     };
-    auto greeting_handler = [&](const message::Greeting& body) {};
-    auto notify_handler = [&](const message::Notify& body) {};
     auto game_state_update_handler = [&](const message::GameStateUpdate& body) {
       Window::gameScene->updateState(SceneState(body));
     };
-    auto user_state_update_handler = [&](const message::UserStateUpdate& body) {
-    };
+    auto any_handler = [](const message::Message::Body&) {};
 
     auto message_handler = boost::make_overloaded_function(
-        assign_handler, greeting_handler, notify_handler,
-        game_state_update_handler, user_state_update_handler);
+        assign_handler, game_state_update_handler, any_handler);
 
     boost::apply_visitor(message_handler, m.body);
   };

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -12,7 +12,6 @@
 #include <cstdio>
 #include <ctime>
 #include <iostream>
-#include <magic_enum.hpp>
 #include <network/message.hpp>
 #include <network/tcp_client.hpp>
 #include <string>
@@ -74,14 +73,9 @@ std::unique_ptr<Client> network_init(boost::asio::io_context& io_context) {
   Addr server_addr{config["server_address"], config["server_port"]};
 
   PlayerID player_id;
-  auto connect_handler = [&](tcp::endpoint endpoint, Client& client) {
-    std::cout << "(Client::connect) Connected to " << endpoint.address() << ":"
-              << endpoint.port() << std::endl;
-  };
+  auto connect_handler = [](tcp::endpoint endpoint, Client& client) {};
 
   auto read_handler = [&](const message::Message& m, Client& client) {
-    std::cout << "(Connection::read) Received\n" << m << std::endl;
-
     auto assign_handler = [&](const message::Assign& body) {
       player_id = body.player_id;
       my_player_id = player_id;
@@ -101,11 +95,7 @@ std::unique_ptr<Client> network_init(boost::asio::io_context& io_context) {
   };
 
   auto write_handler = [&](std::size_t bytes_transferred,
-                           const message::Message& m, Client& client) {
-    std::cout << "(Connection::write, " << magic_enum::enum_name(m.type)
-              << ") Successfully wrote " << bytes_transferred
-              << " bytes to server" << std::endl;
-  };
+                           const message::Message& m, Client& client) {};
   auto client = std::make_unique<Client>(
       io_context, server_addr, connect_handler, read_handler, write_handler);
   return client;

--- a/src/network/message.cpp
+++ b/src/network/message.cpp
@@ -6,14 +6,14 @@
 
 namespace message {
 
-std::string Message::toString() const {
+std::string Message::to_string() const {
   std::string body_str =
-      boost::apply_visitor([](auto b) { return b.toString(); }, body);
+      boost::apply_visitor([](auto b) { return b.to_string(); }, body);
 
   // clang-format off
   std::string str =
       std::string("") +
-      "{" +                                                             "\n" // NOLINT
+      "{" +                                                                     "\n" // NOLINT
       "  type: " + std::string(magic_enum::enum_name(type)) + "," +             "\n" // NOLINT
       "  metadata: {," +                                                        "\n" // NOLINT
       "    player_id: " + boost::uuids::to_string(metadata.player_id) + "," +   "\n" // NOLINT
@@ -28,22 +28,76 @@ std::string Message::toString() const {
 }
 
 std::ostream& operator<<(std::ostream& os, const message::Message& m) {
-  return os << m.toString();
+  return os << m.to_string();
 }
 
 Type get_type(const Message::Body& body) {
-  auto assign = [&](const message::Assign&) { return Type::Assign; };
-  auto greeting = [&](const message::Greeting&) { return Type::Greeting; };
-  auto notify = [&](const message::Notify&) { return Type::Notify; };
-  auto gamestate = [&](const message::GameStateUpdate&) {
-    return Type::GameStateUpdate;
-  };
-  auto userstate = [&](const message::UserStateUpdate&) {
-    return Type::UserStateUpdate;
-  };
+  auto assign = [](const Assign&) { return Type::Assign; };
+  auto greeting = [](const Greeting&) { return Type::Greeting; };
+  auto notify = [](const Notify&) { return Type::Notify; };
+  auto gamestate = [](const GameStateUpdate&) { return Type::GameStateUpdate; };
+  auto userstate = [](const UserStateUpdate&) { return Type::UserStateUpdate; };
   auto overload = boost::make_overloaded_function(assign, greeting, notify,
                                                   gamestate, userstate);
   return boost::apply_visitor(overload, body);
+}
+
+std::string Assign::to_string() const {
+  return "assigning player_id: " + boost::uuids::to_string(player_id);
+}
+
+std::string Greeting::to_string() const { return greeting; }
+
+std::string Notify::to_string() const { return message; }
+
+std::string GameStateUpdateItem::to_string() const {
+  // clang-format off
+    std::string str = std::string("") + "{\n" +
+                      "  id: " + std::to_string(id) +
+                      ",\n" +
+                      "  position: {\n" +
+                      "  " + std::to_string(posx) +
+                      ", " + std::to_string(posy) +
+                      ", " + std::to_string(posz) +
+                      "\n" +
+                      "  },\n" +
+                      "  heading: " + std::to_string(heading) +
+                      ",\n" +
+                      "}";
+  // clang-format on
+  return str;
+}
+
+std::string GameStateUpdate::to_string() const {
+  // clang-format off
+    std::string str = std::string("") + "{...\n" +
+                      "game things:\n";
+  // clang-format on
+  for (auto i : things) {
+    str += i->to_string();
+  }
+  str += "\n}...\n";
+  return str;
+}
+
+std::string UserStateUpdate::to_string() const {
+  // clang-format off
+    std::string str = std::string("") + "{\n" +
+                      "  id: " + std::to_string(id) +
+                      ",\n" +
+                      "  movement delta: {\n" +
+                      "  " + std::to_string(movx) +
+                      ", " + std::to_string(movy) +
+                      ", " + std::to_string(movz) +
+                      "\n" +
+                      "  },\n" +
+                      "  jump: " + std::to_string(jump) +
+                      ",\n" +
+                      "  heading: " + std::to_string(heading) +
+                      ",\n" +
+                      "}";
+  // clang-format on
+  return str;
 }
 
 }  // namespace message

--- a/src/network/message.cpp
+++ b/src/network/message.cpp
@@ -1,8 +1,8 @@
+#include <boost/functional/overloaded_function.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include <boost/variant.hpp>
 #include <magic_enum.hpp>
 #include <network/message.hpp>
-
-#include "boost/uuid/uuid_io.hpp"
 
 namespace message {
 
@@ -29,6 +29,21 @@ std::string Message::toString() const {
 
 std::ostream& operator<<(std::ostream& os, const message::Message& m) {
   return os << m.toString();
+}
+
+Type get_type(const Message::Body& body) {
+  auto assign = [&](const message::Assign&) { return Type::Assign; };
+  auto greeting = [&](const message::Greeting&) { return Type::Greeting; };
+  auto notify = [&](const message::Notify&) { return Type::Notify; };
+  auto gamestate = [&](const message::GameStateUpdate&) {
+    return Type::GameStateUpdate;
+  };
+  auto userstate = [&](const message::UserStateUpdate&) {
+    return Type::UserStateUpdate;
+  };
+  auto overload = boost::make_overloaded_function(assign, greeting, notify,
+                                                  gamestate, userstate);
+  return boost::apply_visitor(overload, body);
 }
 
 }  // namespace message

--- a/src/network/tcp_client.cpp
+++ b/src/network/tcp_client.cpp
@@ -1,3 +1,4 @@
+#include <boost/variant.hpp>
 #include <cstddef>
 #include <iostream>
 #include <memory>
@@ -24,6 +25,11 @@ Client::Client(boost::asio::io_context& io_context, Addr& addr,
             std::cerr << "(Connection::read) Error: " << ec.message()
                       << std::endl;
             return;
+          }
+
+          if (const message::Assign* body =
+                  boost::get<message::Assign>(&m.body)) {
+            player_id_ = m.metadata.player_id;
           }
 
           read_handler(m, *this);

--- a/src/network/tcp_client.cpp
+++ b/src/network/tcp_client.cpp
@@ -19,14 +19,14 @@ Client::Client(boost::asio::io_context& io_context, Addr& addr,
           return;
         }
 
+        std::cout << "(Client::connect) Connected to " << endpoint.address()
+                  << ":" << endpoint.port() << std::endl;
+
         auto conn_read_handler = [=](boost::system::error_code ec,
                                      const message::Message& m) {
-          if (ec) {
-            std::cerr << "(Connection::read) Error: " << ec.message()
-                      << std::endl;
-            return;
-          }
+          if (ec) return;
 
+          // save player_id assigned by the server
           if (const message::Assign* body =
                   boost::get<message::Assign>(&m.body)) {
             player_id_ = body->player_id;
@@ -39,11 +39,7 @@ Client::Client(boost::asio::io_context& io_context, Addr& addr,
         auto conn_write_handler = [=](boost::system::error_code ec,
                                       std::size_t bytes_transferred,
                                       const message::Message& m) {
-          if (ec) {
-            std::cerr << "(Connection::write) Error: " << ec.message()
-                      << std::endl;
-            return;
-          }
+          if (ec) return;
 
           write_handler(bytes_transferred, m, *this);
         };

--- a/src/network/tcp_client.cpp
+++ b/src/network/tcp_client.cpp
@@ -29,7 +29,7 @@ Client::Client(boost::asio::io_context& io_context, Addr& addr,
 
           if (const message::Assign* body =
                   boost::get<message::Assign>(&m.body)) {
-            player_id_ = m.metadata.player_id;
+            player_id_ = body->player_id;
           }
 
           read_handler(m, *this);

--- a/src/network/tcp_server.cpp
+++ b/src/network/tcp_server.cpp
@@ -97,21 +97,15 @@ void Server::do_accept() {
       std::cout << "(Connection::read) Received:\n" << m << std::endl;
 
       PlayerID player_id = m.metadata.player_id;
-      auto assign_handler = [&](const message::Assign& body) {};
       auto greeting_handler = [&](const message::Greeting& body) {
         std::string greeting =
-            "Hello, player " + boost::uuids::to_string(player_id);
+            "Hello, player " + boost::uuids::to_string(player_id) + "!";
         write<message::Greeting>(player_id, greeting);
       };
-      auto notify_handler = [&](const message::Notify& body) {};
-      auto game_state_update_handler =
-          [&](const message::GameStateUpdate& body) {};
-      auto user_state_update_handler =
-          [&](const message::UserStateUpdate& body) {};
+      auto any_handler = [](const message::Message::Body&) {};
 
-      auto message_handler = boost::make_overloaded_function(
-          assign_handler, greeting_handler, notify_handler,
-          game_state_update_handler, user_state_update_handler);
+      auto message_handler =
+          boost::make_overloaded_function(greeting_handler, any_handler);
       boost::apply_visitor(message_handler, m.body);
 
       read(player_id);


### PR DESCRIPTION
This PR adds:

* simpler `write` API for messages
* changes to `message::Assign`, store `player_id` inside body
* replace multiple empty message handlers with [one single fallback handler](https://github.com/ucsd-cse125-sp23/group-4/blob/74b4feeb346339cd669554c2d952f5237527e3e5/src/client/main.cpp#L79-L94)
* consolidate network logs in the `Connection` class

Before writing messages, looked something like:

```cpp
auto type = message::Type::UserStateUpdate;
message::Metadata metadata{player_id, std::time(nullptr)};
message::UserStateUpdate body{1, 0.5, 0.5, 0.5, true, 0.9};
message::Message m{type, metadata, body};
client.write(m);
```

With the new `client.write` API, the above can be rewritten as:

```cpp
client.write<message::UserStateUpdate>(1, 0.5, 0.5, 0.5, true, 0.9);
```
> `Client` now automatically saves the `player_id` (sent from the server), so 
> metadata can be generated by `Client` rather than manually. The arguments
> for the `message::Body` struct (`Assign`, `Notify`, `UserStateUpdate`, etc) are 
> forwarded from `client.write` to the corresponding constructor and the 
> `message::Type` is automatically deduced from the `message::Body`.