### PR TITLE
Throttle client messages

### DIFF
--- a/include/client/graphics/Camera.h
+++ b/include/client/graphics/Camera.h
@@ -32,7 +32,7 @@ class Camera : public GameThing {
 
   Camera();
 
-  message::UserStateUpdate update(float dt);
+  void update(float dt);
 
   void SetPositionTarget(glm::vec3 v) {
     position_target = v + glm::vec3(0, 4, 0);  // center above player

--- a/include/client/graphics/GameThing.h
+++ b/include/client/graphics/GameThing.h
@@ -60,11 +60,13 @@ class GameThing : public Node {
   Transform transform;
   float azimuth = 0;  // for visuals only (aka heading)
 
-  virtual message::UserStateUpdate update(float dt) {
+  virtual void update(float dt) {
     // --- example (spin spin) ---
     transform.rotation += glm::vec3(0, 30 * dt, 0);  // spin on y axis
     transform.updateMtx(&transformMtx);  // needed to update node matrix
+  }
 
+  virtual message::UserStateUpdate pollInput() {
     return message::UserStateUpdate();
   }
 

--- a/include/client/graphics/GameThing.h
+++ b/include/client/graphics/GameThing.h
@@ -94,7 +94,7 @@ class GameThing : public Node {
   }
   void setPositionTarget(glm::vec3 pos) {
     // interpolated!
-    position_p = position_t;
+    position_p = transform.position;
     position_t = pos;
     lerp_p = 0.0f;
   }

--- a/include/client/graphics/Player.h
+++ b/include/client/graphics/Player.h
@@ -23,16 +23,13 @@ class Player : public GameThing, InputListener {
 
   PlayerModel* pmodel;  // visual information
 
-  float time;  // how long we've been tagged
-  bool tagged;
-
   Player() {
-    time = 0;
     pmodel = nullptr;
-    tagged = true;
   }
 
-  message::UserStateUpdate update(float dt);
+  message::UserStateUpdate pollInput();
+
+  void update(float dt);
   glm::vec3 move(glm::vec3 movement);
 
   void faceDirection(glm::vec3 direction);

--- a/include/client/graphics/Player.h
+++ b/include/client/graphics/Player.h
@@ -23,9 +23,7 @@ class Player : public GameThing, InputListener {
 
   PlayerModel* pmodel;  // visual information
 
-  Player() {
-    pmodel = nullptr;
-  }
+  Player() { pmodel = nullptr; }
 
   message::UserStateUpdate pollInput();
 

--- a/include/client/graphics/Scene.h
+++ b/include/client/graphics/Scene.h
@@ -164,8 +164,10 @@ class Scene {
   void setToUserFocus(GameThing* t);
   void init(void);
 
-  message::UserStateUpdate update(float delta);         // broadcast to net
-  void updateState(message::GameStateUpdate newState);  // receive from net
+  message::UserStateUpdate pollInput();                  // broadcast to net
+  void receiveState(message::GameStateUpdate newState);  // receive from net
+
+  void update(float delta);
 
   void drawHUD(GLFWwindow* window);
   void draw();

--- a/include/client/graphics/Window.h
+++ b/include/client/graphics/Window.h
@@ -13,7 +13,7 @@
 class Window {
  public:
   static int fps;
-  static int tps;  // ticks per second
+  static int ups;  // updates from network per second
 
   // Window Properties
   static int width;

--- a/include/client/graphics/Window.h
+++ b/include/client/graphics/Window.h
@@ -6,14 +6,15 @@
 
 #pragma once
 
-#include <network/message.hpp>
-
 #include "Scene.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
 class Window {
  public:
+  static int fps;
+  static int tps;  // ticks per second
+
   // Window Properties
   static int width;
   static int height;
@@ -34,8 +35,7 @@ class Window {
   static void resizeCallback(GLFWwindow* window, int width, int height);
 
   // update and draw functions
-  static message::UserStateUpdate idleCallback(GLFWwindow* window,
-                                               float deltaTime);
+  static void idleCallback(GLFWwindow* window, float deltaTime);
   static void displayCallback(GLFWwindow*);
 
   // helper to reset the camera

--- a/src/client/graphics/Camera.cpp
+++ b/src/client/graphics/Camera.cpp
@@ -68,11 +68,11 @@ void Camera::CamZoom(float y) {
   SetDistance(dist);
 }
 
-message::UserStateUpdate Camera::update(float dt) {
+void Camera::update(float dt) {
   // interpolate camera
   position_prev = glm::lerp(position_prev, position_target, lerpSpeed * dt);
 
-  if (!Fixed) return message::UserStateUpdate();
+  if (!Fixed) return;
 
   vec3 moveLocal = vec3(0);
 
@@ -97,7 +97,7 @@ message::UserStateUpdate Camera::update(float dt) {
 
   if (length(moveLocal) > 0) move_local(moveLocal);
 
-  return message::UserStateUpdate();
+  return;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/client/graphics/Player.cpp
+++ b/src/client/graphics/Player.cpp
@@ -9,10 +9,14 @@ using glm::mat4x4;
 using glm::vec3;
 using glm::vec4;
 
-message::UserStateUpdate Player::update(float dt) {
-  // interpolate states
+void Player::update(float dt) {
+  // interpolate between old to new state
   updateInterpolate(dt);
 
+  if (pmodel) pmodel->update(dt);
+}
+
+message::UserStateUpdate Player::pollInput() {
   if (!isUser) return message::UserStateUpdate();
 
   if (camera && camera->Fixed)
@@ -46,10 +50,7 @@ message::UserStateUpdate Player::update(float dt) {
   vec3 moveWorld = vec3(0);
   if (moving) {
     moveWorld = move(moveLocal);
-    if (pmodel) pmodel->update(dt);
   }
-
-  if (tagged) time += dt;  // move this to server TODO
 
   // Get ready to send a message to the server: ***
   message::UserStateUpdate myInputState;

--- a/src/client/graphics/Scene.cpp
+++ b/src/client/graphics/Scene.cpp
@@ -14,6 +14,7 @@ adapted from CSE 167 - Matthew
 #include <stack>
 
 #include "Scene.inl"  // The scene init definition
+#include "client/graphics/Window.h"
 
 using glm::mat4x4;
 using glm::vec3;
@@ -154,6 +155,21 @@ void Scene::drawHUD(GLFWwindow* window) {
     glWindowPos2f(10.0f, static_cast<float>(height) - 25);
     glutBitmapString(GLUT_BITMAP_TIMES_ROMAN_24, string);
   }
+
+  // draw FPS
+  std::string fps_text = std::to_string(Window::fps) + " FPS";
+  std::string ups_text = std::to_string(Window::ups) + " UPS";
+  const unsigned char* stringFPS =
+      reinterpret_cast<const unsigned char*>(fps_text.c_str());
+  const unsigned char* stringUPS =
+      reinterpret_cast<const unsigned char*>(ups_text.c_str());
+  glColor3f(0.3f, 1.0f, 0.3f);
+  glWindowPos2f(static_cast<float>(width) - 50,
+                static_cast<float>(height) - 25);
+  glutBitmapString(GLUT_BITMAP_HELVETICA_10, stringFPS);
+  glWindowPos2f(static_cast<float>(width) - 50,
+                static_cast<float>(height) - 35);
+  glutBitmapString(GLUT_BITMAP_HELVETICA_10, stringUPS);
 }
 void Scene::draw() {
   // Pre-draw sequence:

--- a/src/client/graphics/Scene.cpp
+++ b/src/client/graphics/Scene.cpp
@@ -68,19 +68,28 @@ void Scene::setToUserFocus(GameThing* t) {
   t->childnodes.push_back(camera);  // parent camera to player
 }
 
-message::UserStateUpdate Scene::update(float delta) {
+void Scene::update(float delta) {
+  for (auto e : gamethings) {
+    e->update(delta);
+  }
+}
+
+message::UserStateUpdate Scene::pollInput() {
   message::UserStateUpdate ourPlayerUpdate = message::UserStateUpdate();
 
   for (auto e : gamethings) {
-    auto currUpdate = e->update(delta);
+    auto currUpdate = e->pollInput();
 
-    if (e->isUser) ourPlayerUpdate = currUpdate;
+    if (e->isUser) {
+      ourPlayerUpdate = currUpdate;
+      break;
+    }
   }
 
   return ourPlayerUpdate;
 }
 
-void Scene::updateState(message::GameStateUpdate newState) {
+void Scene::receiveState(message::GameStateUpdate newState) {
   // check if new graphical objects need to be created
   for (auto& t : newState.things) {
     // TODO(matthew): change gamethings to a map
@@ -121,7 +130,8 @@ void Scene::drawHUD(GLFWwindow* window) {
       Player* player = dynamic_cast<Player*>(e);
       std::string name = player->name;
       glm::vec3 position = player->transform.position;
-      player_times[name] = player->time;
+      // player_times[name] = player->time;  // player.time deprecated,
+      // use game state in future
       const unsigned char* cname =
           reinterpret_cast<const unsigned char*>(name.c_str());
       glColor3f(1.0f, 1.0f, 1.0f);

--- a/src/client/graphics/Window.cpp
+++ b/src/client/graphics/Window.cpp
@@ -166,11 +166,8 @@ void Window::resizeCallback(GLFWwindow* window, int width, int height) {
 ////////////////////////////////////////////////////////////////////////////////
 
 // update and draw functions
-message::UserStateUpdate Window::idleCallback(GLFWwindow* window,
-                                              float deltaTime) {
-  auto inputChanges = gameScene->update(deltaTime);
-
-  return inputChanges;  // player input to be written to server
+void Window::idleCallback(GLFWwindow* window, float deltaTime) {
+  gameScene->update(deltaTime);
 }
 
 void Window::displayCallback(GLFWwindow* window) {

--- a/src/client/graphics/Window.cpp
+++ b/src/client/graphics/Window.cpp
@@ -20,6 +20,9 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
+int Window::fps;
+int Window::ups;
+
 // Window Properties
 int Window::width;
 int Window::height;

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -83,7 +83,7 @@ std::unique_ptr<Client> network_init() {
       net_assigned = true;
     };
     auto game_state_update_handler = [](const message::GameStateUpdate& body) {
-      Window::gameScene->updateState(body);
+      Window::gameScene->receiveState(body);
     };
     auto any_handler = [](const message::Message::Body&) {};
 
@@ -147,30 +147,49 @@ int main(int argc, char* argv[]) {
 
   // Delta time logic (see
   // https://stackoverflow.com/questions/20390028/c-using-glfwgettime-for-a-fixed-time-step)
+  const double limitFPS = 1.0 / 60.0;
   double lastTime = glfwGetTime();
+  double timer = lastTime;
+  double deltaTimer = 0;
+  int frames = 0, updates = 0;
 
   // Loop while GLFW window should stay open.
   while (!game_exit && !glfwWindowShouldClose(window)) {
     // - Measure time
     double nowTime = glfwGetTime();
     double deltaTime = nowTime - lastTime;
+    deltaTimer += (nowTime - lastTime) / limitFPS;
     lastTime = nowTime;
 
-    // POLL FROM SERVER
-    client->poll();
+    // - Only update at 60 frames / s
+    while (deltaTimer >= 1.0) {
+      // POLL FROM SERVER
+      client->poll();
 
-    // Idle callback. Updating local objects, input, etc.
-    // Get a message back of all updates
-    message::UserStateUpdate mout = Window::idleCallback(window, deltaTime);
+      // Idle callback. Updating local objects, input, etc.
+      // Get a message back of all updates
+      message::UserStateUpdate mout = Window::gameScene->pollInput();
 
-    // OUTPUT TO SERVER
-    if (net_assigned && mout.id >= 0)
-      client->write<message::UserStateUpdate>(mout);
+      // OUTPUT TO SERVER
+      if (net_assigned && mout.id >= 0)
+        client->write<message::UserStateUpdate>(mout);
+
+      updates++;
+      deltaTimer--;
+    }
 
     // Main render display callback. Rendering of objects is done here.
+    Window::idleCallback(window, deltaTime);
     Window::displayCallback(window);
+    frames++;
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(16));
+    // - Reset after one second
+    if (glfwGetTime() - timer > 1.0) {
+      timer++;
+      Window::fps = frames;
+      Window::tps = updates;
+      updates = 0, frames = 0;
+    }
   }
 
   Window::cleanUp();

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -142,6 +142,7 @@ int main(int argc, char* argv[]) {
     client->poll();
 
     Window::displayCallback(window);  // TODO: this should be lobby draw
+    std::this_thread::sleep_for(std::chrono::milliseconds(16));
   }
 
   // Delta time logic (see
@@ -168,6 +169,8 @@ int main(int argc, char* argv[]) {
 
     // Main render display callback. Rendering of objects is done here.
     Window::displayCallback(window);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(16));
   }
 
   Window::cleanUp();


### PR DESCRIPTION
Fixed performance issues with sending messages out from clients at 300+ fps. Client message writing is now capped at 60 fps. Tested with 5 clients open locally, no noticeable problems. Appears smooth

Some scene methods were renamed for clarity. pollInput() added, update() now is only in charge of camera/player interpolation and camera input.