### PR TITLE
Handle player disconnect, minor client refactor

### DIFF
--- a/include/client/graphics/GameThing.h
+++ b/include/client/graphics/GameThing.h
@@ -54,7 +54,7 @@ struct Transform {
 // a GameThing (tm)
 class GameThing : public Node {
  public:
-  int netId = -1;  // used to connect with network/core data (-1 means unset)
+  int id = -1;  // used to connect with network/core data (-1 means unset)
   bool isUser = false;  // controls whether we want to read input and send it
 
   Transform transform;

--- a/include/client/graphics/Scene.h
+++ b/include/client/graphics/Scene.h
@@ -168,7 +168,7 @@ class Scene {
   void setToUserFocus(GameThing* t);
   void init(void);
 
-  message::UserStateUpdate pollInput();                  // broadcast to net
+  message::UserStateUpdate pollUpdate();                 // broadcast to net
   void receiveState(message::GameStateUpdate newState);  // receive from net
 
   void update(float delta);

--- a/include/client/graphics/Scene.h
+++ b/include/client/graphics/Scene.h
@@ -20,6 +20,7 @@
 #include <map>
 #include <network/message.hpp>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -112,7 +113,8 @@ class Scene {
   // by setting the child_nodes.
   std::map<std::string, Node*> node;
 
-  std::vector<GameThing*> gamethings;
+  std::vector<GameThing*> localGameThings;
+  std::unordered_map<int, GameThing*> networkGameThings;
 
   std::map<char, Character> Characters;
 
@@ -120,7 +122,7 @@ class Scene {
     camera = camFromWindow;
     node["_camera"] = camera;
     camera->name = "_camera";
-    gamethings.push_back(camera);
+    localGameThings.push_back(camera);
 
     sceneResources = new SceneResourceMap();
 
@@ -161,6 +163,7 @@ class Scene {
   }
 
   Player* createPlayer(int id);
+  void removePlayer(int id);
   void initFromServer(int myid);
   void setToUserFocus(GameThing* t);
   void init(void);

--- a/include/client/graphics/Window.h
+++ b/include/client/graphics/Window.h
@@ -35,8 +35,8 @@ class Window {
   static void resizeCallback(GLFWwindow* window, int width, int height);
 
   // update and draw functions
-  static void idleCallback(GLFWwindow* window, float deltaTime);
-  static void displayCallback(GLFWwindow*);
+  static void update(GLFWwindow* window, float deltaTime);
+  static void draw(GLFWwindow*);
 
   // helper to reset the camera
   static void resetCamera();

--- a/include/network/tcp_server.hpp
+++ b/include/network/tcp_server.hpp
@@ -15,12 +15,14 @@ using message::ClientID;
 class Server {
  public:
   using AcceptHandler = std::function<void(ClientID, Server&)>;
+  using CloseHandler = std::function<void(ClientID, Server&)>;
   using ReadHandler = std::function<void(const message::Message&, Server&)>;
   using WriteHandler =
       std::function<void(std::size_t, const message::Message&, Server&)>;
   using TickHandler = std::function<void(Server&)>;
 
-  Server(int port, AcceptHandler, ReadHandler, WriteHandler, TickHandler);
+  Server(int port, AcceptHandler, CloseHandler, ReadHandler, WriteHandler,
+         TickHandler);
 
   void write(const ClientID&, const message::Message&);
   void write_all(message::Message&);
@@ -39,6 +41,7 @@ class Server {
 
   boost::asio::io_context io_context_;
   AcceptHandler accept_handler_;
+  CloseHandler close_handler_;
   ReadHandler read_handler_;
   WriteHandler write_handler_;
   TickHandler tick_handler_;

--- a/include/server/game.hpp
+++ b/include/server/game.hpp
@@ -18,18 +18,17 @@ struct GameThing {
   message::GameStateUpdateItem to_network() const;
 };
 
-using GameThingMap = std::unordered_map<int, GameThing>;
-
 // stored in server
 class Game {
  public:
   Game();
 
   int create_player();
+  void remove_player(int);
   void update(const message::UserStateUpdate&);
   void tick();
   std::unordered_map<int, message::GameStateUpdateItem> to_network();
 
  private:
-  GameThingMap game_things_;
+  std::unordered_map<int, GameThing> game_things_;
 };

--- a/include/server/game.hpp
+++ b/include/server/game.hpp
@@ -13,6 +13,7 @@ struct GameThing {
   ControlModifierData* control;
 
   GameThing(int, Player*, ControlModifierData*);
+
   void move(float, float, float);  // NOLINT
   void update(const message::UserStateUpdate& update);
   message::GameStateUpdateItem to_network() const;

--- a/src/client/graphics/Player.cpp
+++ b/src/client/graphics/Player.cpp
@@ -52,16 +52,7 @@ message::UserStateUpdate Player::pollInput() {
     moveWorld = move(moveLocal);
   }
 
-  // Get ready to send a message to the server: ***
-  message::UserStateUpdate myInputState;
-  myInputState.id = netId;
-  myInputState.movx = moveWorld.x;
-  myInputState.movy = 0;
-  myInputState.movz = moveWorld.z;
-  myInputState.heading = azimuth;
-  myInputState.jump = jumping;
-
-  return myInputState;
+  return {id, moveWorld.x, 0, moveWorld.z, jumping, azimuth};
 }
 
 vec3 Player::move(vec3 movement) {

--- a/src/client/graphics/Scene.cpp
+++ b/src/client/graphics/Scene.cpp
@@ -49,10 +49,22 @@ Player* Scene::createPlayer(int id) {
   player->transform.position = vec3(4 + id * 3, 2, 4 + id * 5);
   player->transform.updateMtx(&(player->transformMtx));
 
-  gamethings.push_back(player);
+  networkGameThings.insert({id, player});
   node["world"]->childnodes.push_back(player);
 
   return player;
+}
+
+void Scene::removePlayer(int id) {
+  auto player = networkGameThings.at(id);
+
+  // remove player from world
+  auto& nodes = node["world"]->childnodes;
+  auto it = std::find(nodes.begin(), nodes.end(), player);
+  nodes.erase(it);
+
+  networkGameThings.erase(id);
+  delete player;
 }
 
 void Scene::initFromServer(int myid) { _myPlayerId = myid; }
@@ -70,52 +82,32 @@ void Scene::setToUserFocus(GameThing* t) {
 }
 
 void Scene::update(float delta) {
-  for (auto e : gamethings) {
-    e->update(delta);
-  }
+  for (auto& thing : localGameThings) thing->update(delta);
+  for (auto& [_, thing] : networkGameThings) thing->update(delta);
 }
 
 message::UserStateUpdate Scene::pollInput() {
-  message::UserStateUpdate ourPlayerUpdate = message::UserStateUpdate();
+  if (!networkGameThings.count(_myPlayerId)) return {};
 
-  for (auto e : gamethings) {
-    auto currUpdate = e->pollInput();
-
-    if (e->isUser) {
-      ourPlayerUpdate = currUpdate;
-      break;
-    }
-  }
-
-  return ourPlayerUpdate;
+  return networkGameThings.at(_myPlayerId)->pollInput();
 }
 
 void Scene::receiveState(message::GameStateUpdate newState) {
-  // check if new graphical objects need to be created
-  for (auto& t : newState.things) {
-    // TODO(matthew): change gamethings to a map
-    bool exists = false;
-    for (auto e : gamethings) {
-      if (e->netId == t.second.id) {
-        exists = true;
-        break;
-      }
-    }
+  // update existing items, create new item if it doesn't exist
+  for (auto& [id, state] : newState.things) {
+    // TODO: handle items besides Player as well
+    if (!networkGameThings.count(id)) createPlayer(id);
 
-    // if t isn't in our gamethings yet, add it now
-    if (!exists) createPlayer(t.second.id);
+    auto thing = networkGameThings.at(id);
+    thing->updateFromState(state);
   }
 
-  // loop through GameThings and update their state
-  for (auto e : gamethings) {
-    int currId = e->netId;
+  // remove items that don't exist on the server anymore
+  std::vector<int> removedIds;
+  for (auto& [id, _] : networkGameThings)
+    if (!newState.things.count(id)) removedIds.push_back(id);
 
-    if (currId == -1) continue;  // skip thing
-
-    message::GameStateUpdateItem currState = newState.things.at(currId);
-    // please check for non-null too!
-    e->updateFromState(currState);
-  }
+  for (int id : removedIds) removePlayer(id);
 }
 
 void Scene::drawHUD(GLFWwindow* window) {
@@ -126,9 +118,8 @@ void Scene::drawHUD(GLFWwindow* window) {
 
   std::map<std::string, float> player_times;
 
-  for (GameThing* e : gamethings) {
-    if (dynamic_cast<Player*>(e) != nullptr) {
-      Player* player = dynamic_cast<Player*>(e);
+  for (auto& [_, thing] : networkGameThings) {
+    if (auto player = dynamic_cast<Player*>(thing); player != nullptr) {
       std::string name = player->name;
       glm::vec3 position = player->transform.position;
       // player_times[name] = player->time;  // player.time deprecated,
@@ -171,6 +162,7 @@ void Scene::drawHUD(GLFWwindow* window) {
                 static_cast<float>(height) - 35);
   glutBitmapString(GLUT_BITMAP_HELVETICA_10, stringUPS);
 }
+
 void Scene::draw() {
   // Pre-draw sequence:
   if (myPlayer) camera->SetPositionTarget(myPlayer->transform.position);

--- a/src/client/graphics/Scene.cpp
+++ b/src/client/graphics/Scene.cpp
@@ -86,7 +86,7 @@ void Scene::update(float delta) {
   for (auto& [_, thing] : networkGameThings) thing->update(delta);
 }
 
-message::UserStateUpdate Scene::pollInput() {
+message::UserStateUpdate Scene::pollUpdate() {
   if (!networkGameThings.count(_myPlayerId)) return {};
 
   return networkGameThings.at(_myPlayerId)->pollInput();

--- a/src/client/graphics/Scene.cpp
+++ b/src/client/graphics/Scene.cpp
@@ -33,7 +33,7 @@ Player* Scene::createPlayer(int id) {
   std::string playername = "player" + std::to_string(id);
 
   Player* player = new Player();
-  player->netId = id;
+  player->id = id;
   if (isUser) {
     setToUserFocus(player);
   }

--- a/src/client/graphics/Scene.inl
+++ b/src/client/graphics/Scene.inl
@@ -156,7 +156,6 @@ void Scene::init(void) {
   sceneResources->models["wasp"]->mesh = sceneResources->meshes["wasp"];
   sceneResources->models["wasp"]->material = sceneResources->materials["wood"];
 
-
   // THE player !!!
   sceneResources->models["playerRef"] = new Model;
   sceneResources->models["playerRef"]->mesh = sceneResources->meshes["player"];
@@ -207,19 +206,19 @@ void Scene::init(void) {
   // Add stuff to game updateables
   GameThing* thing_example = new GameThing;
   thing_example->name = "GT_teapot";
-  gamethings.push_back(thing_example);
+  localGameThings.push_back(thing_example);
 
   GameThing* thing_cube = new GameThing;
   thing_cube->name = "GT_cube";
-  gamethings.push_back(thing_cube);
+  localGameThings.push_back(thing_cube);
 
   GameThing* thing_modeltest = new GameThing;
   thing_modeltest->name = "GT_playerTest";
-  gamethings.push_back(thing_modeltest);
+  localGameThings.push_back(thing_modeltest);
 
   GameThing* thing_modeltestB = new GameThing;
   thing_modeltestB->name = "GT_playerTestB";
-  gamethings.push_back(thing_modeltestB);
+  localGameThings.push_back(thing_modeltestB);
 
   Player* player = new Player();
   player->camera = camera;               // give a reference to the game camera

--- a/src/client/graphics/Window.cpp
+++ b/src/client/graphics/Window.cpp
@@ -169,11 +169,11 @@ void Window::resizeCallback(GLFWwindow* window, int width, int height) {
 ////////////////////////////////////////////////////////////////////////////////
 
 // update and draw functions
-void Window::idleCallback(GLFWwindow* window, float deltaTime) {
+void Window::update(GLFWwindow* window, float deltaTime) {
   gameScene->update(deltaTime);
 }
 
-void Window::displayCallback(GLFWwindow* window) {
+void Window::draw(GLFWwindow* window) {
   // Gets events, including input such as keyboard and mouse or window resizing.
   glfwPollEvents();
 

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -146,7 +146,7 @@ int main(int argc, char* argv[]) {
     std::cout << "Waiting for server to assign pid..." << std::endl;
     client->poll();
 
-    Window::displayCallback(window);  // TODO: this should be lobby draw
+    Window::draw(window);  // TODO: this should be lobby draw
     std::this_thread::sleep_for(std::chrono::milliseconds(16));
   }
 
@@ -182,9 +182,6 @@ int main(int argc, char* argv[]) {
       deltaTimer--;
     }
 
-    // Main render display callback. Rendering of objects is done here.
-    Window::idleCallback(window, deltaTime);
-    Window::displayCallback(window);
     frames++;
 
     // - Reset after one second
@@ -194,6 +191,9 @@ int main(int argc, char* argv[]) {
       Window::ups = updates;
       updates = 0, frames = 0;
     }
+    // update and render scene
+    Window::update(window, time_since_prev_frame);
+    Window::draw(window);
 
     // prevent drawing too fast...
     std::this_thread::sleep_for(std::chrono::milliseconds(2));

--- a/src/network/message.cpp
+++ b/src/network/message.cpp
@@ -1,6 +1,7 @@
 #include <boost/functional/overloaded_function.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/variant.hpp>
+#include <ctime>
 #include <magic_enum.hpp>
 #include <network/message.hpp>
 
@@ -10,6 +11,10 @@ std::string Message::to_string() const {
   std::string body_str =
       boost::apply_visitor([](auto b) { return b.to_string(); }, body);
 
+  char buffer[80];
+  std::strftime(buffer, sizeof(buffer), "%m-%d-%Y %I:%M:%S %p",
+                std::localtime(&metadata.time));
+
   // clang-format off
   std::string str =
       std::string("") +
@@ -17,7 +22,7 @@ std::string Message::to_string() const {
       "  type: " + std::string(magic_enum::enum_name(type)) + "," +     "\n"
       "  metadata: {," +                                                "\n"
       "    client_id: " + boost::uuids::to_string(metadata.id) + "," + "\n"
-      "    time: " + std::to_string(metadata.time) + "," +              "\n"
+      "    time: " + buffer + "," +              "\n"
       "  }," +                                                          "\n"
       "  body: {" +                                                     "\n"
       + body_str +                                                      "\n"
@@ -43,36 +48,36 @@ Type get_type(const Message::Body& body) {
 }
 
 std::string Assign::to_string() const {
-  return "assigning player_id: " + std::to_string(pid);
+  return "    assigned_pid: " + std::to_string(pid);
 }
 
-std::string Greeting::to_string() const { return greeting; }
+std::string Greeting::to_string() const { return "    greeting: " + greeting; }
 
-std::string Notify::to_string() const { return message; }
+std::string Notify::to_string() const { return "    message: " + message; }
 
 std::string GameStateUpdateItem::to_string() const {
   // clang-format off
     std::string str = std::string("") +
-      "      id: " + std::to_string(id) + "," +     "\n"
-      "      position: {" +                         "\n"
-      "        " + std::to_string(posx) + "," +     "\n"
-      "        " + std::to_string(posy) + "," +     "\n"
-      "        " + std::to_string(posz) + "," +     "\n"
-      "      }," +                                  "\n"
-      "      heading: " + std::to_string(heading) + "\n";
+      "      {"                                       "\n"
+      "        id: " + std::to_string(id) + "," +     "\n"
+      "        position: {" +                         "\n"
+      "          " + std::to_string(posx) + "," +     "\n"
+      "          " + std::to_string(posy) + "," +     "\n"
+      "          " + std::to_string(posz) + "," +     "\n"
+      "        }," +                                  "\n"
+      "        heading: " + std::to_string(heading) + "\n"
+      "      },"                                      "\n";
   // clang-format on
   return str;
 }
 
 std::string GameStateUpdate::to_string() const {
-  // clang-format off
-    std::string str = std::string("") + "{...\n" +
-                      "game things:\n";
-  // clang-format on
-  for (auto i : things) {
-    str += i.second.to_string();
+  std::string str = "    game_things: [\n";
+  for (auto& [id, thing] : things) {
+    str += thing.to_string();
   }
-  str += "\n}...\n";
+  str += "    ]";
+
   return str;
 }
 

--- a/src/server/game.cpp
+++ b/src/server/game.cpp
@@ -39,7 +39,10 @@ int Game::create_player() {
   return player->pid;
 }
 
-void Game::remove_player(int pid) { game_things_.erase(pid); }
+void Game::remove_player(int pid) {
+  game_things_.at(pid).player->markRemove();
+  game_things_.erase(pid);
+}
 
 void Game::update(const message::UserStateUpdate& update) {
   game_things_.at(update.id).update(update);

--- a/src/server/game.cpp
+++ b/src/server/game.cpp
@@ -39,6 +39,8 @@ int Game::create_player() {
   return player->pid;
 }
 
+void Game::remove_player(int pid) { game_things_.erase(pid); }
+
 void Game::update(const message::UserStateUpdate& update) {
   game_things_.at(update.id).update(update);
 }


### PR DESCRIPTION
This PR adds support for end-to-end player removal, providing a client-server synchronization mechanism for on-demand item creation/removal. While player removal isn't completely required for the game, these changes enable us to add items/powerups, which will definitely be created and removed often, with relative ease. To support player removal on the client, the existing organization on client was refactored to better fit item removal and improve readability.

Notable changes:
* `Scene.gamethings` was split into `Scene.localGameThings` and `Scene.networkGameThings` to distinguish elements strictly on the client (e.g. map elements) and elements interacting with the server (e.g. players and eventually items).
* refactor client render loop for readability (consolidate time logic, rename stuff)
* logged messages are properly aligned

Renames:
* `GameThing.netId` -> `GameThing.id`
* `Scene::pollInput` -> `Scene::pollUpdate`
* `Window::idleCallback` -> `Window::update`
* `Window::displayCallback` -> `Window::draw`