### PR TITLE
Basic lobby implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_CXX_STANDARD 17)
 set(FETCHCONTENT_QUIET FALSE)
 
+add_compile_definitions(
+  BOOST_FUNCTIONAL_OVERLOADED_FUNCTION_CONFIG_OVERLOAD_MAX=20)
+
 add_subdirectory(src/config)
 add_subdirectory(src/core)
 add_subdirectory(src/network)

--- a/include/network/message.hpp
+++ b/include/network/message.hpp
@@ -22,7 +22,8 @@ enum class Type {
   GameStateUpdate,
   UserStateUpdate,
   LobbyUpdate,
-  LobbyPlayerUpdate
+  LobbyPlayerUpdate,
+  GameStart,
 };
 
 struct Metadata {
@@ -128,9 +129,20 @@ struct LobbyUpdate {
   }
 };
 
+struct GameStart {
+  std::unordered_map<int, bool> client_states;
+
+  std::string to_string() const;
+  template <typename Archive>
+  void serialize(Archive& ar, unsigned int) {
+    ar& client_states;
+  }
+};
+
 struct Message {
-  using Body = boost::variant<Assign, Greeting, Notify, GameStateUpdate,
-                              UserStateUpdate, LobbyUpdate, LobbyPlayerUpdate>;
+  using Body =
+      boost::variant<Assign, Greeting, Notify, GameStateUpdate, UserStateUpdate,
+                     LobbyUpdate, LobbyPlayerUpdate, GameStart>;
   Type type;
   Metadata metadata;
   Body body;

--- a/include/network/message.hpp
+++ b/include/network/message.hpp
@@ -15,7 +15,15 @@ namespace message {
 
 using ClientID = boost::uuids::uuid;
 
-enum class Type { Assign, Greeting, Notify, GameStateUpdate, UserStateUpdate };
+enum class Type {
+  Assign,
+  Greeting,
+  Notify,
+  GameStateUpdate,
+  UserStateUpdate,
+  LobbyUpdate,
+  LobbyPlayerUpdate
+};
 
 struct Metadata {
   ClientID id;       // client id
@@ -91,7 +99,29 @@ struct UserStateUpdate {
   float heading;
 
   std::string to_string() const;
+  template <typename Archive>
+  void serialize(Archive& ar, unsigned int) {
+    ar& id& movx& movy& movz& jump& heading;
+  }
+};
 
+struct LobbyPlayer {
+  int id;
+  std::string skin;
+  bool is_ready;
+
+  std::string to_string() const;
+  template <typename Archive>
+  void serialize(Archive& ar, unsigned int) {
+    ar& id& skin& is_ready;
+  }
+};
+using LobbyPlayerUpdate = LobbyPlayer;  // type alias for client usage
+
+struct LobbyUpdate {
+  std::unordered_map<int, LobbyPlayer> players;
+
+  std::string to_string() const;
   template <typename Archive>
   void serialize(Archive& ar, unsigned int) {
     ar& players;
@@ -100,7 +130,7 @@ struct UserStateUpdate {
 
 struct Message {
   using Body = boost::variant<Assign, Greeting, Notify, GameStateUpdate,
-                              UserStateUpdate>;
+                              UserStateUpdate, LobbyUpdate, LobbyPlayerUpdate>;
   Type type;
   Metadata metadata;
   Body body;

--- a/include/network/message.hpp
+++ b/include/network/message.hpp
@@ -29,8 +29,8 @@ struct Metadata {
 
 struct Assign {
   int pid;
-  std::string to_string() const;
 
+  std::string to_string() const;
   template <typename Archive>
   void serialize(Archive& ar, unsigned int) {
     ar& pid;
@@ -39,8 +39,8 @@ struct Assign {
 
 struct Greeting {
   std::string greeting;
-  std::string to_string() const;
 
+  std::string to_string() const;
   template <typename Archive>
   void serialize(Archive& ar, unsigned int) {
     ar& greeting;
@@ -49,8 +49,8 @@ struct Greeting {
 
 struct Notify {
   std::string message;
-  std::string to_string() const;
 
+  std::string to_string() const;
   template <typename Archive>
   void serialize(Archive& ar, unsigned int) {
     ar& message;
@@ -63,23 +63,19 @@ struct GameStateUpdateItem {
   float posy;
   float posz;
   float heading;
-  std::string to_string() const;
 
+  std::string to_string() const;
   template <typename Archive>
   void serialize(Archive& ar, unsigned int) {
-    ar& id;
-    ar& posx;
-    ar& posy;
-    ar& posz;
-    ar& heading;
+    ar& id& posx& posy& posz& heading;
   }
 };
 
 struct GameStateUpdate {
   std::unordered_map<int, GameStateUpdateItem> things;
   // add global params later
-  std::string to_string() const;
 
+  std::string to_string() const;
   template <typename Archive>
   void serialize(Archive& ar, unsigned int) {
     ar& things;
@@ -93,16 +89,12 @@ struct UserStateUpdate {
   float movz;
   bool jump;
   float heading;
+
   std::string to_string() const;
 
   template <typename Archive>
   void serialize(Archive& ar, unsigned int) {
-    ar& id;
-    ar& movx;
-    ar& movy;
-    ar& movz;
-    ar& jump;
-    ar& heading;
+    ar& players;
   }
 };
 

--- a/include/network/tcp_server.hpp
+++ b/include/network/tcp_server.hpp
@@ -24,6 +24,7 @@ class Server {
   Server(int port, AcceptHandler, CloseHandler, ReadHandler, WriteHandler,
          TickHandler);
 
+  void start_tick();
   void write(const ClientID&, const message::Message&);
   void write_all(message::Message&);
   template <typename T, typename... Args>

--- a/include/network/tcp_server.hpp
+++ b/include/network/tcp_server.hpp
@@ -31,7 +31,7 @@ class Server {
   template <typename T, typename... Args>
   void write_all(Args&&...);
 
-  constexpr static std::chrono::milliseconds TICK_RATE{50};
+  static constexpr std::chrono::milliseconds TICK_RATE{50};
 
  private:
   void do_accept();

--- a/include/server/game.hpp
+++ b/include/server/game.hpp
@@ -24,7 +24,7 @@ class Game {
  public:
   Game();
 
-  int create_player();
+  int add_player();
   void remove_player(int);
   void update(const message::UserStateUpdate&);
   void tick();

--- a/include/server/game.hpp
+++ b/include/server/game.hpp
@@ -3,7 +3,6 @@
 #include <core/lib.hpp>
 #include <network/message.hpp>
 #include <unordered_map>
-#include <unordered_set>
 
 #include "client/graphics/ColliderImporter.h"
 
@@ -26,7 +25,6 @@ class GameThing {
   ControlModifierData* control;
 };
 
-// stored in server
 class Game {
  public:
   Game();
@@ -39,25 +37,4 @@ class Game {
 
  private:
   std::unordered_map<int, GameThing> game_things_;
-};
-
-class Manager {
- public:
-  enum class Status {
-    Lobby,
-    InGame,
-    GameOver,
-  };
-
-  static const std::size_t MAX_PLAYERS = 2;
-
-  message::LobbyUpdate handle_lobby_update(message::LobbyPlayerUpdate&);
-  bool check_ready();
-  void handle_game_update(message::UserStateUpdate&);
-  message::GameStateUpdate get_game_update();
-
-  Status status_ = Status::Lobby;
-
- private:
-  std::unordered_set<int> ready_players;
 };

--- a/include/server/game.hpp
+++ b/include/server/game.hpp
@@ -19,10 +19,10 @@ class GameThing {
  private:
   void move(float, float, float);  // NOLINT
 
-  int id;
-  float heading;
-  Player* player;
-  ControlModifierData* control;
+  int id_;
+  float heading_;
+  Player* player_;
+  ControlModifierData* control_;
 };
 
 class Game {

--- a/include/server/game.hpp
+++ b/include/server/game.hpp
@@ -3,6 +3,7 @@
 #include <core/lib.hpp>
 #include <network/message.hpp>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "client/graphics/ColliderImporter.h"
 
@@ -38,4 +39,25 @@ class Game {
 
  private:
   std::unordered_map<int, GameThing> game_things_;
+};
+
+class Manager {
+ public:
+  enum class Status {
+    Lobby,
+    InGame,
+    GameOver,
+  };
+
+  static const std::size_t MAX_PLAYERS = 2;
+
+  message::LobbyUpdate handle_lobby_update(message::LobbyPlayerUpdate&);
+  bool check_ready();
+  void handle_game_update(message::UserStateUpdate&);
+  message::GameStateUpdate get_game_update();
+
+  Status status_ = Status::Lobby;
+
+ private:
+  std::unordered_set<int> ready_players;
 };

--- a/include/server/game.hpp
+++ b/include/server/game.hpp
@@ -6,17 +6,23 @@
 
 #include "client/graphics/ColliderImporter.h"
 
-struct GameThing {
+// represents a new Player right now
+// TODO: figure out how to support items later on
+class GameThing {
+ public:
+  GameThing(int, Player*, ControlModifierData*);
+
+  void update(const message::UserStateUpdate& update);
+  void remove();
+  message::GameStateUpdateItem to_network() const;
+
+ private:
+  void move(float, float, float);  // NOLINT
+
   int id;
   float heading;
   Player* player;
   ControlModifierData* control;
-
-  GameThing(int, Player*, ControlModifierData*);
-
-  void move(float, float, float);  // NOLINT
-  void update(const message::UserStateUpdate& update);
-  message::GameStateUpdateItem to_network() const;
 };
 
 // stored in server

--- a/include/server/manager.hpp
+++ b/include/server/manager.hpp
@@ -33,6 +33,6 @@ class Manager {
     bool is_ready;
   };
 
-  Game game;
+  Game game_;
   std::unordered_map<int, Player> players_;
 };

--- a/include/server/manager.hpp
+++ b/include/server/manager.hpp
@@ -18,6 +18,7 @@ class Manager {
   int add_player();
   void remove_player(int);
   message::LobbyUpdate handle_lobby_update(const message::LobbyPlayerUpdate&);
+  message::LobbyUpdate get_lobby_update();
   bool check_ready();
   void handle_game_update(const message::UserStateUpdate&);
   void tick_game();
@@ -31,8 +32,6 @@ class Manager {
     std::string skin;
     bool is_ready;
   };
-
-  message::LobbyUpdate get_lobby_update();
 
   Game game;
   std::unordered_map<int, Player> players_;

--- a/include/server/manager.hpp
+++ b/include/server/manager.hpp
@@ -17,9 +17,9 @@ class Manager {
 
   int add_player();
   void remove_player(int);
-  message::LobbyUpdate handle_lobby_update(message::LobbyPlayerUpdate&);
+  message::LobbyUpdate handle_lobby_update(const message::LobbyPlayerUpdate&);
   bool check_ready();
-  void handle_game_update(message::UserStateUpdate&);
+  void handle_game_update(const message::UserStateUpdate&);
   void tick_game();
   message::GameStateUpdate get_game_update();
 

--- a/include/server/manager.hpp
+++ b/include/server/manager.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <network/message.hpp>
+#include <server/game.hpp>
+#include <string>
+#include <unordered_map>
+
+class Manager {
+ public:
+  enum class Status {
+    Lobby,
+    InGame,
+    GameOver,
+  };
+
+  static const std::size_t MAX_PLAYERS = 2;
+
+  int add_player();
+  void remove_player(int);
+  message::LobbyUpdate handle_lobby_update(message::LobbyPlayerUpdate&);
+  bool check_ready();
+  void handle_game_update(message::UserStateUpdate&);
+  void tick_game();
+  message::GameStateUpdate get_game_update();
+
+  Status status_ = Status::Lobby;
+
+ private:
+  struct Player {
+    int pid;
+    std::string skin;
+    bool is_ready;
+  };
+
+  message::LobbyUpdate get_lobby_update();
+
+  Game game;
+  std::unordered_map<int, Player> players_;
+};

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -1,5 +1,4 @@
 // clang-format off
-#include <ios>
 #ifdef __APPLE__
 #define GLFW_INCLUDE_GLCOREARB
 #include <OpenGL/gl3.h>
@@ -18,6 +17,7 @@
 #include <config/lib.hpp>
 #include <cstdio>
 #include <ctime>
+#include <ios>
 #include <iostream>
 #include <network/message.hpp>
 #include <network/tcp_client.hpp>

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -1,4 +1,5 @@
 // clang-format off
+#include <ios>
 #ifdef __APPLE__
 #define GLFW_INCLUDE_GLCOREARB
 #include <OpenGL/gl3.h>
@@ -26,7 +27,7 @@
 #include "Window.h"
 
 bool net_assigned = false;
-
+bool is_game_ready = false;
 bool game_exit = false;
 
 void error_callback(int error, const char* description) {
@@ -87,13 +88,22 @@ std::unique_ptr<Client> network_init() {
 
       net_assigned = true;
     };
+
     auto game_state_update_handler = [](const message::GameStateUpdate& body) {
       Window::gameScene->receiveState(body);
     };
+
+    auto lobby_update_handler = [](const message::LobbyUpdate& body) {};
+
+    auto game_ready_handler = [](const message::GameStart& body) {
+      is_game_ready = true;
+    };
+
     auto any_handler = [](const message::Message::Body&) {};
 
     auto message_handler = boost::make_overloaded_function(
-        assign_handler, game_state_update_handler, any_handler);
+        assign_handler, game_state_update_handler, lobby_update_handler,
+        game_ready_handler, any_handler);
     boost::apply_visitor(message_handler, m.body);
   };
 
@@ -147,6 +157,20 @@ int main(int argc, char* argv[]) {
     client->poll();
 
     Window::draw(window);  // TODO: this should be lobby draw
+    std::this_thread::sleep_for(std::chrono::milliseconds(16));
+  }
+
+  // TODO: replace with lobby UI
+  std::ios_base::sync_with_stdio(false);
+  std::cout << "Press Enter when you are ready to start..." << std::endl;
+  std::cin.get();
+  client->write<message::LobbyPlayerUpdate>(Window::gameScene->_myPlayerId, "",
+                                            true);
+  std::ios_base::sync_with_stdio(true);
+
+  while (!is_game_ready) {
+    client->poll();
+    Window::draw(window);
     std::this_thread::sleep_for(std::chrono::milliseconds(16));
   }
 

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -161,12 +161,10 @@ int main(int argc, char* argv[]) {
   }
 
   // TODO: replace with lobby UI
-  std::ios_base::sync_with_stdio(false);
   std::cout << "Press Enter when you are ready to start..." << std::endl;
   std::cin.get();
   client->write<message::LobbyPlayerUpdate>(Window::gameScene->_myPlayerId, "",
                                             true);
-  std::ios_base::sync_with_stdio(true);
 
   while (!is_game_ready) {
     client->poll();

--- a/src/network/message.cpp
+++ b/src/network/message.cpp
@@ -40,10 +40,19 @@ Type get_type(const Message::Body& body) {
   auto assign = [](const Assign&) { return Type::Assign; };
   auto greeting = [](const Greeting&) { return Type::Greeting; };
   auto notify = [](const Notify&) { return Type::Notify; };
-  auto gamestate = [](const GameStateUpdate&) { return Type::GameStateUpdate; };
-  auto userstate = [](const UserStateUpdate&) { return Type::UserStateUpdate; };
-  auto overload = boost::make_overloaded_function(assign, greeting, notify,
-                                                  gamestate, userstate);
+  auto game_state = [](const GameStateUpdate&) {
+    return Type::GameStateUpdate;
+  };
+  auto user_state = [](const UserStateUpdate&) {
+    return Type::UserStateUpdate;
+  };
+  auto lobby_update = [](const LobbyUpdate&) { return Type::LobbyUpdate; };
+  auto lobby_player_update = [](const LobbyPlayerUpdate&) {
+    return Type::LobbyPlayerUpdate;
+  };
+  auto overload = boost::make_overloaded_function(
+      assign, greeting, notify, game_state, user_state, lobby_update,
+      lobby_player_update);
   return boost::apply_visitor(overload, body);
 }
 
@@ -93,6 +102,26 @@ std::string UserStateUpdate::to_string() const {
       "      jump: " + std::to_string(jump) +       "\n"
       "      heading: " + std::to_string(heading) + "\n";
   // clang-format on
+  return str;
+}
+
+std::string LobbyPlayerUpdate::to_string() const {
+  // clang-format off
+    std::string str = std::string("") +
+      "      id: " + std::to_string(id) + "," +       "\n"
+      "      skin: " + skin +                         "\n"
+      "      is_ready: " + std::to_string(is_ready) + "\n";
+  // clang-format on
+  return str;
+}
+
+std::string LobbyUpdate::to_string() const {
+  std::string str = "    players: [\n";
+  for (auto& [_, player] : players) {
+    str += player.to_string();
+  }
+  str += "    ]";
+
   return str;
 }
 

--- a/src/network/message.cpp
+++ b/src/network/message.cpp
@@ -50,9 +50,10 @@ Type get_type(const Message::Body& body) {
   auto lobby_player_update = [](const LobbyPlayerUpdate&) {
     return Type::LobbyPlayerUpdate;
   };
+  auto game_start = [](const GameStart&) { return Type::GameStart; };
   auto overload = boost::make_overloaded_function(
       assign, greeting, notify, game_state, user_state, lobby_update,
-      lobby_player_update);
+      lobby_player_update, game_start);
   return boost::apply_visitor(overload, body);
 }
 
@@ -108,9 +109,11 @@ std::string UserStateUpdate::to_string() const {
 std::string LobbyPlayerUpdate::to_string() const {
   // clang-format off
     std::string str = std::string("") +
-      "      id: " + std::to_string(id) + "," +       "\n"
-      "      skin: " + skin +                         "\n"
-      "      is_ready: " + std::to_string(is_ready) + "\n";
+      "      {"                                       "\n"
+      "        id: " + std::to_string(id) + "," +       "\n"
+      "        skin: " + skin +                         "\n"
+      "        is_ready: " + std::to_string(is_ready) + "\n"
+      "      },"                                       "\n";
   // clang-format on
   return str;
 }
@@ -124,5 +127,7 @@ std::string LobbyUpdate::to_string() const {
 
   return str;
 }
+
+std::string GameStart::to_string() const { return "    game_start: true"; }
 
 }  // namespace message

--- a/src/network/message.cpp
+++ b/src/network/message.cpp
@@ -73,7 +73,7 @@ std::string GameStateUpdateItem::to_string() const {
 
 std::string GameStateUpdate::to_string() const {
   std::string str = "    game_things: [\n";
-  for (auto& [id, thing] : things) {
+  for (auto& [_, thing] : things) {
     str += thing.to_string();
   }
   str += "    ]";

--- a/src/network/tcp_server.cpp
+++ b/src/network/tcp_server.cpp
@@ -22,9 +22,10 @@ Server::Server(int port, AcceptHandler accept_handler,
       tick_handler_(tick_handler) {
   std::cout << "(Server::Server) Server running on port " << port << std::endl;
   do_accept();
-  tick();
   io_context_.run();
 }
+
+void Server::start_tick() { tick(); }
 
 void Server::tick() {
   auto prev_time = std::chrono::steady_clock::now();

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -1,7 +1,8 @@
 project(server DESCRIPTION "tagguys server executable")
 
-set(_SERVER_SOURCES ${PROJECT_SOURCE_DIR}/main.cpp
-                    ${PROJECT_SOURCE_DIR}/game.cpp)
+set(_SERVER_SOURCES
+    ${PROJECT_SOURCE_DIR}/main.cpp ${PROJECT_SOURCE_DIR}/manager.cpp
+    ${PROJECT_SOURCE_DIR}/game.cpp)
 
 add_executable(server ${_SERVER_SOURCES})
 target_link_libraries(server PRIVATE core network config Boost::asio)

--- a/src/server/game.cpp
+++ b/src/server/game.cpp
@@ -4,25 +4,25 @@
 #include <server/game.hpp>
 
 GameThing::GameThing(int id, Player* p, ControlModifierData* c)
-    : id(id), player(p), control(c), heading(0) {}
+    : id_(id), player_(p), control_(c), heading_(0) {}
 
 void GameThing::move(float x, float y, float z) {  // NOLINT
-  control->horizontalVel = vec3f(x, y, z);
+  control_->horizontalVel = vec3f(x, y, z);
 }
 
 void GameThing::update(const message::UserStateUpdate& update) {
   std::cout << "(GameThing::update) Updating GameThing " << update.id
             << std::endl;
-  control->horizontalVel = vec3f(update.movx, update.movy, update.movz);
-  control->doJump = update.jump;
-  heading = update.heading;
+  control_->horizontalVel = vec3f(update.movx, update.movy, update.movz);
+  control_->doJump = update.jump;
+  heading_ = update.heading;
 }
 
-void GameThing::remove() { player->markRemove(); }
+void GameThing::remove() { player_->markRemove(); }
 
 message::GameStateUpdateItem GameThing::to_network() const {
-  return {id, player->getPos().x, player->getPos().y, player->getPos().z,
-          heading};
+  return {id_, player_->getPos().x, player_->getPos().y, player_->getPos().z,
+          heading_};
 }
 
 Game::Game() {

--- a/src/server/game.cpp
+++ b/src/server/game.cpp
@@ -18,6 +18,8 @@ void GameThing::update(const message::UserStateUpdate& update) {
   heading = update.heading;
 }
 
+void GameThing::remove() { player->markRemove(); }
+
 message::GameStateUpdateItem GameThing::to_network() const {
   return {id, player->getPos().x, player->getPos().y, player->getPos().z,
           heading};
@@ -40,7 +42,7 @@ int Game::add_player() {
 }
 
 void Game::remove_player(int pid) {
-  game_things_.at(pid).player->markRemove();
+  game_things_.at(pid).remove();
   game_things_.erase(pid);
 }
 

--- a/src/server/game.cpp
+++ b/src/server/game.cpp
@@ -33,7 +33,7 @@ Game::Game() {
   initializeLevel(environment);
 }
 
-int Game::create_player() {
+int Game::add_player() {
   auto [player, control] = initializePlayer();
   game_things_.insert({player->pid, GameThing(player->pid, player, control)});
   return player->pid;

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -2,15 +2,15 @@
 #include <boost/functional/overloaded_function.hpp>
 #include <config/lib.hpp>
 #include <network/tcp_server.hpp>
-#include <server/game.hpp>
+#include <server/manager.hpp>
 
 int main(int argc, char* argv[]) {
-  auto game = Game();
+  auto manager = Manager();
   std::unordered_map<ClientID, int, boost::hash<ClientID>> pids;
 
-  auto accept_handler = [&game, &pids](ClientID client_id, Server& server) {
+  auto accept_handler = [&manager, &pids](ClientID client_id, Server& server) {
     // assign client their player_id
-    int pid = game.add_player();
+    int pid = manager.add_player();
     pids[client_id] = pid;
     server.write<message::Assign>(client_id, pid);
 
@@ -21,12 +21,12 @@ int main(int argc, char* argv[]) {
     server.write_all<message::Notify>(notification);
   };
 
-  auto close_handler = [&game, &pids](ClientID client_id, Server& server) {
+  auto close_handler = [&manager, &pids](ClientID client_id, Server& server) {
     int pid = pids.at(client_id);
-    game.remove_player(pid);
+    manager.remove_player(pid);
   };
 
-  auto read_handler = [&game](const message::Message& m, Server& server) {
+  auto read_handler = [&manager](const message::Message& m, Server& server) {
     ClientID client_id = m.metadata.id;
 
     auto greeting_handler = [&server,
@@ -37,7 +37,9 @@ int main(int argc, char* argv[]) {
     };
 
     auto user_state_update_handler =
-        [&game](const message::UserStateUpdate& body) { game.update(body); };
+        [&manager](const message::UserStateUpdate& body) {
+          manager.handle_game_update(body);
+        };
 
     auto any_handler = [](const message::Message::Body&) {};
 
@@ -49,11 +51,11 @@ int main(int argc, char* argv[]) {
   auto write_handler = [](std::size_t bytes_transferred,
                           const message::Message& m, Server& server) {};
 
-  auto tick_handler = [&game](Server& server) {
+  auto tick_handler = [&manager](Server& server) {
     // advance game, send update to client
-    game.tick();
-    auto things = game.to_network();
-    server.write_all<message::GameStateUpdate>(things);
+    manager.tick_game();
+    auto update = manager.get_game_update();
+    server.write_all<message::GameStateUpdate>(update);
   };
 
   auto config = get_config();

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -10,7 +10,7 @@ int main(int argc, char* argv[]) {
 
   auto accept_handler = [&game, &pids](ClientID client_id, Server& server) {
     // assign client their player_id
-    int pid = game.create_player();
+    int pid = game.add_player();
     pids[client_id] = pid;
     server.write<message::Assign>(client_id, pid);
 

--- a/src/server/manager.cpp
+++ b/src/server/manager.cpp
@@ -30,7 +30,7 @@ message::LobbyUpdate Manager::get_lobby_update() {
 }
 
 bool Manager::check_ready() {
-  int ready_count;
+  int ready_count = 0;
   for (auto& [_, player] : players_)
     if (player.is_ready) ready_count++;
 

--- a/src/server/manager.cpp
+++ b/src/server/manager.cpp
@@ -15,10 +15,8 @@ void Manager::remove_player(int pid) {
 }
 
 message::LobbyUpdate Manager::handle_lobby_update(
-    message::LobbyPlayerUpdate& update) {
-  if (update.is_ready) {
-    players_.at(update.id).is_ready = true;
-  }
+    const message::LobbyPlayerUpdate& update) {
+  if (update.is_ready) players_.at(update.id).is_ready = true;
 
   return get_lobby_update();
 }
@@ -36,10 +34,13 @@ bool Manager::check_ready() {
   for (auto& [_, player] : players_)
     if (player.is_ready) ready_count++;
 
-  return ready_count == MAX_PLAYERS;
+  bool is_ready = ready_count == MAX_PLAYERS;
+  if (is_ready) status_ = Status::InGame;
+
+  return is_ready;
 }
 
-void Manager::handle_game_update(message::UserStateUpdate& update) {
+void Manager::handle_game_update(const message::UserStateUpdate& update) {
   game.update(update);
 }
 

--- a/src/server/manager.cpp
+++ b/src/server/manager.cpp
@@ -1,0 +1,50 @@
+#include <network/message.hpp>
+#include <server/manager.hpp>
+#include <unordered_map>
+
+int Manager::add_player() {
+  int pid = game.add_player();
+  players_.insert({pid, {pid, "", false}});
+
+  return pid;
+}
+
+void Manager::remove_player(int pid) {
+  game.remove_player(pid);
+  players_.erase(pid);
+}
+
+message::LobbyUpdate Manager::handle_lobby_update(
+    message::LobbyPlayerUpdate& update) {
+  if (update.is_ready) {
+    players_.at(update.id).is_ready = true;
+  }
+
+  return get_lobby_update();
+}
+
+message::LobbyUpdate Manager::get_lobby_update() {
+  std::unordered_map<int, message::LobbyPlayer> players;
+  for (auto& [id, player] : players_)
+    players.insert({id, {player.pid, player.skin, player.is_ready}});
+
+  return {players};
+}
+
+bool Manager::check_ready() {
+  int ready_count;
+  for (auto& [_, player] : players_)
+    if (player.is_ready) ready_count++;
+
+  return ready_count == MAX_PLAYERS;
+}
+
+void Manager::handle_game_update(message::UserStateUpdate& update) {
+  game.update(update);
+}
+
+void Manager::tick_game() { game.tick(); }
+
+message::GameStateUpdate Manager::get_game_update() {
+  return {game.to_network()};
+}

--- a/src/server/manager.cpp
+++ b/src/server/manager.cpp
@@ -3,14 +3,14 @@
 #include <unordered_map>
 
 int Manager::add_player() {
-  int pid = game.add_player();
+  int pid = game_.add_player();
   players_.insert({pid, {pid, "", false}});
 
   return pid;
 }
 
 void Manager::remove_player(int pid) {
-  game.remove_player(pid);
+  game_.remove_player(pid);
   players_.erase(pid);
 }
 
@@ -41,11 +41,11 @@ bool Manager::check_ready() {
 }
 
 void Manager::handle_game_update(const message::UserStateUpdate& update) {
-  game.update(update);
+  game_.update(update);
 }
 
-void Manager::tick_game() { game.tick(); }
+void Manager::tick_game() { game_.tick(); }
 
 message::GameStateUpdate Manager::get_game_update() {
-  return {game.to_network()};
+  return {game_.to_network()};
 }


### PR DESCRIPTION
This PR expands server to support lobby logic and provides a basic 2-person lobby implementation on the client and server.

* Adds `LobbyUpdate`, `LobbyPlayerUpdate`, and `GameStart` messages
* Adds a `Manager` class in the server to support managing the lobby and game logic, as well as switching between the two
* Provides a sample implementation of the lobby messages, by having the user press Enter in the terminal to trigger a ready message

This code should eventually be integrated with #37 (Lobby UI)

Tested with 4 clients on the lab computers.