### PR TITLE
Add support for items/effects/events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 
 build
+ninja-build
 out
 compile_commands.json
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,3 +20,16 @@ add_subdirectory(src/server)
 
 enable_testing()
 add_subdirectory(tests)
+
+# copy static assets to executable directory
+add_custom_target(
+  copy_static_files
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/assets
+          $<TARGET_FILE_DIR:client>/assets
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/config.json
+          $<TARGET_FILE_DIR:client>
+  COMMAND
+    ${CMAKE_COMMAND} -E copy
+    ${FETCHCONTENT_BASE_DIR}/sfml-src/extlibs/bin/x64/openal32.dll
+    $<TARGET_FILE_DIR:client>)
+add_dependencies(client copy_static_files)

--- a/config.json
+++ b/config.json
@@ -2,5 +2,5 @@
   "server_address": "localhost",
   "server_port": 2400,
   "map_draw_file": "assets/model/dev/map_wk9.obj",
-  "map_data_file": "assets/model/dev/map_wk9.data.obj"
+  "map_data_file": "assets/model/map-data.obj"
 }

--- a/include/client/graphics/Start.h
+++ b/include/client/graphics/Start.h
@@ -35,9 +35,7 @@ class Start : public Scene, public InputListener {
     }
   }
 
-  void init(void) override;
-
-  void draw();
+  void draw() override;
 
   void drawName();
 

--- a/include/network/effect.hpp
+++ b/include/network/effect.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-enum class Event {
+enum class Effect {
   ReducedGravity,
   IncreasedGravity,
   SlipperyPhysics,  // ReducedFriction?

--- a/include/network/event.hpp
+++ b/include/network/event.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+enum class Event {
+  ReducedGravity,
+  IncreasedGravity,
+  SlipperyPhysics,  // ReducedFriction?
+  Speed,            // IncreasedVelocity?
+  Slow,             // ReducedVelocity?
+  Freeze,           // idrk what this means
+  Confuse,          // same ^
+  Attract,
+  Repel
+};

--- a/include/network/item.hpp
+++ b/include/network/item.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+enum class Item {
+  GiftBox,
+};

--- a/include/network/message.hpp
+++ b/include/network/message.hpp
@@ -7,9 +7,12 @@
 #include <boost/uuid/uuid_serialize.hpp>
 #include <boost/variant.hpp>
 #include <ctime>
+#include <network/item.hpp>
 #include <ostream>
 #include <string>
 #include <unordered_map>
+
+#include "core/game/event/Event.h"
 
 namespace message {
 
@@ -24,6 +27,10 @@ enum class Type {
   LobbyUpdate,
   LobbyPlayerUpdate,
   GameStart,
+  JumpEvent,
+  LandEvent,
+  ItemPickupEvent,
+  TagEvent,
 };
 
 struct Metadata {
@@ -139,10 +146,53 @@ struct GameStart {
   }
 };
 
+struct JumpEvent {
+  int pid;
+
+  std::string to_string() const;
+  template <typename Archive>
+  void serialize(Archive& ar, unsigned int) {
+    ar& pid;
+  }
+};
+
+struct LandEvent {
+  int pid;
+
+  std::string to_string() const;
+  template <typename Archive>
+  void serialize(Archive& ar, unsigned int) {
+    ar& pid;
+  }
+};
+
+struct ItemPickupEvent {
+  int pid;
+  Item item;
+
+  std::string to_string() const;
+  template <typename Archive>
+  void serialize(Archive& ar, unsigned int) {
+    ar& pid& item;
+  }
+};
+
+struct TagEvent {
+  int tagger;
+  int taggee;
+
+  std::string to_string() const;
+  template <typename Archive>
+  void serialize(Archive& ar, unsigned int) {
+    ar& tagger& taggee;
+  }
+};
+
 struct Message {
   using Body =
       boost::variant<Assign, Greeting, Notify, GameStateUpdate, UserStateUpdate,
-                     LobbyUpdate, LobbyPlayerUpdate, GameStart>;
+                     LobbyUpdate, LobbyPlayerUpdate, GameStart, JumpEvent,
+                     LandEvent, ItemPickupEvent, TagEvent>;
   Type type;
   Metadata metadata;
   Body body;

--- a/include/network/message.hpp
+++ b/include/network/message.hpp
@@ -2,15 +2,18 @@
 
 #include <boost/serialization/unordered_map.hpp>
 #include <boost/serialization/variant.hpp>
+#include <boost/serialization/vector.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/uuid_serialize.hpp>
 #include <boost/variant.hpp>
 #include <ctime>
+#include <network/effect.hpp>
 #include <network/item.hpp>
 #include <ostream>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "core/game/event/Event.h"
 
@@ -79,22 +82,29 @@ struct GameStateUpdateItem {
   float posy;
   float posz;
   float heading;
+  int score;
+  float speed;
+  bool is_grounded;
+  bool is_tagged;
+  std::vector<Effect> effects;
 
   std::string to_string() const;
   template <typename Archive>
   void serialize(Archive& ar, unsigned int) {
-    ar& id& posx& posy& posz& heading;
+    ar& id& posx& posy& posz& heading& score& speed& is_grounded& is_tagged&
+        effects;
   }
 };
 
 struct GameStateUpdate {
   std::unordered_map<int, GameStateUpdateItem> things;
-  // add global params later
+  int tagged_player;
+  float round_time;
 
   std::string to_string() const;
   template <typename Archive>
   void serialize(Archive& ar, unsigned int) {
-    ar& things;
+    ar& things& tagged_player& round_time;
   }
 };
 

--- a/include/server/game.hpp
+++ b/include/server/game.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "client/graphics/MapDataImporter.h"
+#include "core/game/event/Event.h"
 
 // represents a new Player right now
 // TODO: figure out how to support items later on
@@ -34,10 +35,19 @@ class Game {
   void remove_player(int);
   void update(const message::UserStateUpdate&);
   void tick();
+  std::vector<message::JumpEvent> get_jump_events();
+  std::vector<message::LandEvent> get_land_events();
+  std::vector<message::ItemPickupEvent> get_item_pickup_events();
+  std::vector<message::TagEvent> get_tag_events();
+  void clear_events();
   std::unordered_map<int, message::GameStateUpdateItem> to_network();
 
  private:
   std::unordered_map<int, GameThing> game_things_;
+  std::vector<JumpEvent> jump_events_;
+  std::vector<LandEvent> land_events_;
+  std::vector<PickupEvent> item_pickup_events_;
+  std::vector<TaggingEvent> tag_events_;
 
   Level* level;
 

--- a/include/server/game.hpp
+++ b/include/server/game.hpp
@@ -12,7 +12,7 @@
 // TODO: figure out how to support items later on
 class GameThing {
  public:
-  GameThing(int, Player*, ControlModifierData*);
+  GameThing(int, Player*, ControlModifierData*, Level*);
 
   void update(const message::UserStateUpdate& update);
   void remove();
@@ -21,6 +21,7 @@ class GameThing {
  private:
   void move(float, float, float);  // NOLINT
 
+  Level* level_;
   int id_;
   float heading_;
   Player* player_;
@@ -49,8 +50,7 @@ class Game {
   std::vector<PickupEvent> item_pickup_events_;
   std::vector<TaggingEvent> tag_events_;
 
-  Level* level;
-
+  Level* level_;
   std::vector<vec3f> map_spawn_points;
   // TODO: add other map things here...
 };

--- a/include/server/manager.hpp
+++ b/include/server/manager.hpp
@@ -25,6 +25,7 @@ class Manager {
   message::GameStateUpdate get_game_update();
 
   Status status_ = Status::Lobby;
+  Game game_;
 
  private:
   struct Player {
@@ -33,6 +34,5 @@ class Manager {
     bool is_ready;
   };
 
-  Game game_;
   std::unordered_map<int, Player> players_;
 };

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -49,9 +49,7 @@ FetchContent_Declare(
   GIT_TAG 18b6cff
   GIT_PROGRESS TRUE)
 # override find_package(zlib)
-FetchContent_MakeAvailable(
-  zlib
-)
+FetchContent_MakeAvailable(zlib)
 file(RENAME ${zlib_SOURCE_DIR}/zconf.h.included ${zlib_SOURCE_DIR}/zconf.h)
 set(ZLIB_ROOT ${zlib_SOURCE_DIR})
 set(ZLIB_LIBRARY zlibstatic)
@@ -59,29 +57,20 @@ set(ZLIB_LIBRARY zlibstatic)
 # turn off install for freetype and assimp
 set(_disable_install TRUE)
 function(install)
-  if (NOT _disable_install)
+  if(NOT _disable_install)
     _install(${ARGV})
   endif()
 endfunction(install)
 
-FetchContent_MakeAvailable(
-    freetype
-    assimp)
+FetchContent_MakeAvailable(freetype assimp)
 set(_disable_install FALSE)
-
 
 FetchContent_Declare(
   SFML
   GIT_REPOSITORY https://github.com/SFML/SFML
   GIT_TAG 2.5.1
   GIT_PROGRESS TRUE)
-FetchContent_MakeAvailable(
-  glew
-  glfw
-  glm
-  freetype
-  imgui
-  SFML)
+FetchContent_MakeAvailable(glew glfw glm freetype imgui SFML)
 
 set(SOURCES
     ${PROJECT_SOURCE_DIR}/main.cpp
@@ -107,8 +96,8 @@ set(SOURCES
     ${PROJECT_SOURCE_DIR}/graphics/Start.cpp)
 
 add_executable(client ${SOURCES})
-target_include_directories(
-  client PRIVATE ${CMAKE_SOURCE_DIR}/include/client/graphics)
+target_include_directories(client
+                           PRIVATE ${CMAKE_SOURCE_DIR}/include/client/graphics)
 target_link_libraries(
   client
   PRIVATE core
@@ -133,19 +122,6 @@ endif()
 
 set_target_properties(
   sfml-audio
-  PROPERTIES CXX_STANDARD 98 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
-
-# Copy OpenAL32.dll to executable directory
-add_custom_command(
-  TARGET client
-  POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy
-          ${FETCHCONTENT_BASE_DIR}/sfml-src/extlibs/bin/x64/openal32.dll
-          "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
-
-# Copy assets folder to executable root directory
-add_custom_command(
-  TARGET client
-  POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/assets"
-          "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/assets")
+  PROPERTIES CXX_STANDARD 98
+             CXX_STANDARD_REQUIRED YES
+             CXX_EXTENSIONS NO)

--- a/src/client/graphics/Scene.cpp
+++ b/src/client/graphics/Scene.cpp
@@ -177,7 +177,7 @@ void Scene::draw() {
 
   while (!dfs_stack.empty()) {
     // Detect whether the search runs into infinite loop
-    if (dfs_stack.size() > std::max(static_cast<int>(node.size()), 100)) {
+    if (dfs_stack.size() > std::max(static_cast<int>(node.size()), 10000)) {
       std::cerr << "Error: The scene graph probably has a closed loop."
                 << std::endl;
       exit(-1);

--- a/src/client/graphics/Start.cpp
+++ b/src/client/graphics/Start.cpp
@@ -2,8 +2,6 @@
 
 #include "Window.h"
 
-void Start::init(void) {}
-
 void Start::update(float delta) {
   timeElapsed += delta;
   offset += (0.25 * delta);

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(client DESCRIPTION "tagguys config file manager")
+project(config DESCRIPTION "tagguys config file manager")
 
 FetchContent_Declare(
   json
@@ -10,6 +10,3 @@ FetchContent_MakeAvailable(json)
 add_library(config ${PROJECT_SOURCE_DIR}/lib.cpp)
 target_include_directories(config PUBLIC ${tagguys_SOURCE_DIR}/include)
 target_link_libraries(config PUBLIC nlohmann_json::nlohmann_json)
-
-configure_file(${CMAKE_SOURCE_DIR}/config.json
-               ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/config.json COPYONLY)

--- a/src/core/game/physics/PObject.cpp
+++ b/src/core/game/physics/PObject.cpp
@@ -141,7 +141,7 @@ void PObject::move(vec3f dPos) {
 
   Environment* environment = this->level->getEnvironment();
   std::pair<PObject*, vec4f> pair = environment->mtv(this);
-  while (pair.first != nullptr) {
+  while (pair.first != nullptr && ite++ < 20) {
     response(this, pair.first, pair.second);
     pair = environment->mtv(this);
   }

--- a/src/core/game/physics/PObject.cpp
+++ b/src/core/game/physics/PObject.cpp
@@ -13,8 +13,8 @@ void PObject::response(PObject* self, PObject* other, vec4f mtv) {
   /*If object is falling and mtv is atleast a little up, the we determine the
    * object to be onGround*/
   if (self->vel.y < 0 && norm.y > 0.1 * (std::abs(norm.x) + std::abs(norm.z))) {
+    if (!self->onGround) self->level->eventManager->fireLandEvent(self);
     self->onGround = true;
-    self->level->eventManager->fireLandEvent(self);
   }
   if (other->isStatic()) {
     self->addPos(vec3f(mtv) * (mtv.w + 0.0001f));
@@ -28,8 +28,8 @@ void PObject::response(PObject* self, PObject* other, vec4f mtv) {
   } else {
     if (other->vel.y < 0 &&
         norm.y / (std::abs(norm.x) + std::abs(norm.z)) > -0.05) {
+      if (!self->onGround) self->level->eventManager->fireLandEvent(self);
       self->onGround = true;
-      self->level->eventManager->fireLandEvent(self);
     }
 
     self->addPos(vec3f(mtv) * (mtv.w * 0.5f + 0.00005f));
@@ -108,8 +108,8 @@ void PObject::move(vec3f dPos) {
     if (norm != vec3f(0, 0, 0)) {
       if (this->vel.y < 0 &&
           norm.y > 0.1 * (std::abs(norm.x) + std::abs(norm.z))) {
+        if (!this->onGround) this->level->eventManager->fireLandEvent(this);
         this->onGround = true;
-        this->level->eventManager->fireLandEvent(this);
       }
 
       vec3f v = tangent(rDPos, norm);

--- a/src/core/game/physics/PowerUp.cpp
+++ b/src/core/game/physics/PowerUp.cpp
@@ -10,5 +10,5 @@ PowerUp::PowerUp(vec3f pos, GlobalEffect* effect)
 void PowerUp::onTrigger(PObject* other) {
   effect->apply(level, other);
   this->markRemove();
-  this->level->eventManager->fireLandEvent(other);
+  this->level->eventManager->firePickupEvent(other);
 }

--- a/src/network/message.cpp
+++ b/src/network/message.cpp
@@ -19,18 +19,17 @@ std::string Message::to_string() const {
                 std::localtime(&metadata.time));
 
   // clang-format off
-  std::string str =
-      std::string("") +
-      "{" +                                                             "\n"
-      "  type: " + std::string(magic_enum::enum_name(type)) + "," +     "\n"
-      "  metadata: {," +                                                "\n"
-      "    client_id: " + boost::uuids::to_string(metadata.id) + "," + "\n"
-      "    time: " + buffer + "," +              "\n"
-      "  }," +                                                          "\n"
-      "  body: {" +                                                     "\n"
-      + body_str +                                                      "\n"
-      "  }" +                                                           "\n"
-      "}";
+  std::string str = std::string("") +
+    "{" +                                                             "\n"
+    "  type: " + std::string(magic_enum::enum_name(type)) + "," +     "\n"
+    "  metadata: {," +                                                "\n"
+    "    client_id: " + boost::uuids::to_string(metadata.id) + "," + "\n"
+    "    time: " + buffer + "," +              "\n"
+    "  }," +                                                          "\n"
+    "  body: {" +                                                     "\n"
+    + body_str +                                                      "\n"
+    "  }" +                                                           "\n"
+    "}";
   // clang-format on
   return str;
 }
@@ -86,21 +85,21 @@ std::string effects_to_string(const std::vector<Effect>& effects) {
 
 std::string GameStateUpdateItem::to_string() const {
   // clang-format off
-    std::string str = std::string("") +
-      "      {"                                               "\n"
-      "        id: " + std::to_string(id) + "," +             "\n"
-      "        position: {" +                                 "\n"
-      "          " + std::to_string(posx) + "," +             "\n"
-      "          " + std::to_string(posy) + "," +             "\n"
-      "          " + std::to_string(posz) + "," +             "\n"
-      "        }," +                                          "\n"
-      "        heading: " + std::to_string(heading) +         "\n"
-      "        score: " + std::to_string(score) +             "\n"
-      "        speed: " + std::to_string(speed) +             "\n"
-      "        is_grounded: " + std::to_string(is_grounded) + "\n"
-      "        is_tagged: " + std::to_string(is_tagged) +     "\n"
-      "        effects: " + effects_to_string(effects) +      "\n"
-      "      },"                                              "\n";
+  std::string str = std::string("") +
+    "      {"                                               "\n"
+    "        id: " + std::to_string(id) + "," +             "\n"
+    "        position: {" +                                 "\n"
+    "          " + std::to_string(posx) + "," +             "\n"
+    "          " + std::to_string(posy) + "," +             "\n"
+    "          " + std::to_string(posz) + "," +             "\n"
+    "        }," +                                          "\n"
+    "        heading: " + std::to_string(heading) +         "\n"
+    "        score: " + std::to_string(score) +             "\n"
+    "        speed: " + std::to_string(speed) +             "\n"
+    "        is_grounded: " + std::to_string(is_grounded) + "\n"
+    "        is_tagged: " + std::to_string(is_tagged) +     "\n"
+    "        effects: " + effects_to_string(effects) +      "\n"
+    "      },"                                              "\n";
   // clang-format on
   return str;
 }
@@ -123,27 +122,27 @@ std::string GameStateUpdate::to_string() const {
 
 std::string UserStateUpdate::to_string() const {
   // clang-format off
-    std::string str = std::string("") +
-      "      id: " + std::to_string(id) + "," +     "\n"
-      "      movement_delta: {" +                   "\n"
-      "        " + std::to_string(movx) + "," +     "\n"
-      "        " + std::to_string(movy) + "," +     "\n"
-      "        " + std::to_string(movz) + "," +     "\n"
-      "      }," +                                  "\n"
-      "      jump: " + std::to_string(jump) +       "\n"
-      "      heading: " + std::to_string(heading) + "\n";
+  std::string str = std::string("") +
+    "      id: " + std::to_string(id) + "," +     "\n"
+    "      movement_delta: {" +                   "\n"
+    "        " + std::to_string(movx) + "," +     "\n"
+    "        " + std::to_string(movy) + "," +     "\n"
+    "        " + std::to_string(movz) + "," +     "\n"
+    "      }," +                                  "\n"
+    "      jump: " + std::to_string(jump) +       "\n"
+    "      heading: " + std::to_string(heading) + "\n";
   // clang-format on
   return str;
 }
 
 std::string LobbyPlayerUpdate::to_string() const {
   // clang-format off
-    std::string str = std::string("") +
-      "      {"                                       "\n"
-      "        id: " + std::to_string(id) + "," +       "\n"
-      "        skin: " + skin +                         "\n"
-      "        is_ready: " + std::to_string(is_ready) + "\n"
-      "      },"                                       "\n";
+  std::string str = std::string("") +
+    "      {"                                       "\n"
+    "        id: " + std::to_string(id) + "," +       "\n"
+    "        skin: " + skin +                         "\n"
+    "        is_ready: " + std::to_string(is_ready) + "\n"
+    "      },"                                       "\n";
   // clang-format on
   return str;
 }
@@ -170,18 +169,18 @@ std::string LandEvent::to_string() const {
 
 std::string ItemPickupEvent::to_string() const {
   // clang-format off
-    std::string str = std::string("") +
-      "      pid: " + std::to_string(pid) + "," +     "\n"
-      "      item: " + std::string(magic_enum::enum_name(item)) + "\n";
+  std::string str = std::string("") +
+    "      pid: " + std::to_string(pid) + "," +     "\n"
+    "      item: " + std::string(magic_enum::enum_name(item)) + "\n";
   // clang-format on
   return str;
 }
 
 std::string TagEvent::to_string() const {
   // clang-format off
-    std::string str = std::string("") +
-      "      tagger: " + std::to_string(tagger) + "," +     "\n"
-      "      taggee: " + std::to_string(taggee) + "\n";
+  std::string str = std::string("") +
+    "      tagger: " + std::to_string(tagger) + "," +     "\n"
+    "      taggee: " + std::to_string(taggee) + "\n";
   // clang-format on
   return str;
 }

--- a/src/network/message.cpp
+++ b/src/network/message.cpp
@@ -3,9 +3,10 @@
 #include <boost/variant.hpp>
 #include <ctime>
 #include <magic_enum.hpp>
+#include <network/effect.hpp>
 #include <network/message.hpp>
-
-#include "core/game/event/Event.h"
+#include <string>
+#include <vector>
 
 namespace message {
 
@@ -74,28 +75,48 @@ std::string Greeting::to_string() const { return "    greeting: " + greeting; }
 
 std::string Notify::to_string() const { return "    message: " + message; }
 
+std::string effects_to_string(const std::vector<Effect>& effects) {
+  if (effects.empty()) return "[]";
+
+  std::string inside;
+  for (auto& e : effects) inside += std::string(magic_enum::enum_name(e)) + ",";
+
+  return "[" + inside + "]";
+}
+
 std::string GameStateUpdateItem::to_string() const {
   // clang-format off
     std::string str = std::string("") +
-      "      {"                                       "\n"
-      "        id: " + std::to_string(id) + "," +     "\n"
-      "        position: {" +                         "\n"
-      "          " + std::to_string(posx) + "," +     "\n"
-      "          " + std::to_string(posy) + "," +     "\n"
-      "          " + std::to_string(posz) + "," +     "\n"
-      "        }," +                                  "\n"
-      "        heading: " + std::to_string(heading) + "\n"
-      "      },"                                      "\n";
+      "      {"                                               "\n"
+      "        id: " + std::to_string(id) + "," +             "\n"
+      "        position: {" +                                 "\n"
+      "          " + std::to_string(posx) + "," +             "\n"
+      "          " + std::to_string(posy) + "," +             "\n"
+      "          " + std::to_string(posz) + "," +             "\n"
+      "        }," +                                          "\n"
+      "        heading: " + std::to_string(heading) +         "\n"
+      "        score: " + std::to_string(score) +             "\n"
+      "        speed: " + std::to_string(speed) +             "\n"
+      "        is_grounded: " + std::to_string(is_grounded) + "\n"
+      "        is_tagged: " + std::to_string(is_tagged) +     "\n"
+      "        effects: " + effects_to_string(effects) +      "\n"
+      "      },"                                              "\n";
   // clang-format on
   return str;
 }
 
 std::string GameStateUpdate::to_string() const {
-  std::string str = "    game_things: [\n";
-  for (auto& [_, thing] : things) {
-    str += thing.to_string();
-  }
-  str += "    ]";
+  std::string game_things = "    game_things: [\n";
+  for (auto& [_, thing] : things) game_things += thing.to_string();
+
+  game_things += "    ]";
+
+  // clang-format off
+  std::string str = std::string("") +
+    "      game_things: " + game_things + "," +               "\n"
+    "      tagged_player: " + std::to_string(tagged_player) + "\n"
+    "      round_time: " + std::to_string(round_time) +       "\n";
+  // clang-format on
 
   return str;
 }

--- a/src/network/message.cpp
+++ b/src/network/message.cpp
@@ -5,6 +5,8 @@
 #include <magic_enum.hpp>
 #include <network/message.hpp>
 
+#include "core/game/event/Event.h"
+
 namespace message {
 
 std::string Message::to_string() const {
@@ -51,9 +53,16 @@ Type get_type(const Message::Body& body) {
     return Type::LobbyPlayerUpdate;
   };
   auto game_start = [](const GameStart&) { return Type::GameStart; };
+  auto jump_event = [](const JumpEvent&) { return Type::JumpEvent; };
+  auto land_event = [](const LandEvent&) { return Type::LandEvent; };
+  auto item_pickup_event = [](const ItemPickupEvent&) {
+    return Type::ItemPickupEvent;
+  };
+  auto tag_event = [](const TagEvent&) { return Type::TagEvent; };
   auto overload = boost::make_overloaded_function(
       assign, greeting, notify, game_state, user_state, lobby_update,
-      lobby_player_update, game_start);
+      lobby_player_update, game_start, jump_event, land_event,
+      item_pickup_event, tag_event);
   return boost::apply_visitor(overload, body);
 }
 
@@ -129,5 +138,31 @@ std::string LobbyUpdate::to_string() const {
 }
 
 std::string GameStart::to_string() const { return "    game_start: true"; }
+
+std::string JumpEvent::to_string() const {
+  return "    pid: " + std::to_string(pid);
+}
+
+std::string LandEvent::to_string() const {
+  return "    pid: " + std::to_string(pid);
+}
+
+std::string ItemPickupEvent::to_string() const {
+  // clang-format off
+    std::string str = std::string("") +
+      "      pid: " + std::to_string(pid) + "," +     "\n"
+      "      item: " + std::string(magic_enum::enum_name(item)) + "\n";
+  // clang-format on
+  return str;
+}
+
+std::string TagEvent::to_string() const {
+  // clang-format off
+    std::string str = std::string("") +
+      "      tagger: " + std::to_string(tagger) + "," +     "\n"
+      "      taggee: " + std::to_string(taggee) + "\n";
+  // clang-format on
+  return str;
+}
 
 }  // namespace message

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -73,6 +73,17 @@ int main(int argc, char* argv[]) {
     manager.tick_game();
     auto update = manager.get_game_update();
     server.write_all<message::GameStateUpdate>(update);
+
+    // notify clients of events
+    for (auto&& e : manager.game_.get_jump_events())
+      server.write_all<message::JumpEvent>(e);
+    for (auto&& e : manager.game_.get_land_events())
+      server.write_all<message::LandEvent>(e);
+    for (auto&& e : manager.game_.get_item_pickup_events())
+      server.write_all<message::ItemPickupEvent>(e);
+    for (auto&& e : manager.game_.get_tag_events())
+      server.write_all<message::TagEvent>(e);
+    manager.game_.clear_events();
   };
 
   auto config = get_config();


### PR DESCRIPTION
This PR adds:

* sending events (`JumpEvent`, `TagEvent`, etc) over the network
* in network, adds `Item` and `Event` enum classes
* in network, update `GameStateUpdateItem` and `GameStateUpdate` messages for more gameplay features
* in core, add missing `registerEventHandler` implementations
* in server, register events with `core`
* in server, check for events and dispatch them every tick
* unify and fix copying of static assets (`config.json`, `assets`, etc) to executable, assets are now properly copied over whenever assets change, even if executable don't need to be rebuilt
* fix class methods in client
* add `Level` member to game management classes