### PR TITLE
Synchronize game loading

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,9 +3,7 @@
   "server_port": 2400,
   "game_duration": 45,
   "game_mode": "single-tagger",
-
-  "player_count": 1,
-
+  "player_count": 2,
   "escape_to_exit": true,
   "map_draw_file": "assets/model/map-final-singlemap.obj",
   "map_data_file": "assets/model/map-data.obj",

--- a/config.json
+++ b/config.json
@@ -17,6 +17,5 @@
   "skin_duck": "demo-duck.fbx",
   "skin_trash panda": "demo-racoon.fbx",
   "skin_unicorn": "demo-unicorn.fbx",
-  "skin_waffle": "demo-waffle.fbx",
-  "game_start_delay": 14
+  "skin_waffle": "demo-waffle.fbx"
 }

--- a/include/client/graphics/Window.h
+++ b/include/client/graphics/Window.h
@@ -53,7 +53,7 @@ class Window {
   static HUD* hud;
 
   // network
-  static std::unique_ptr<Client> client;
+  static std::shared_ptr<Client> client;
   static int my_pid;
 
   // Act as Constructors and desctructors

--- a/include/client/graphics/Window.h
+++ b/include/client/graphics/Window.h
@@ -20,7 +20,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-enum class GamePhase { Start, Lobby, Game, GameOver };
+enum class GamePhase { Start, Lobby, GameLoading, Game, GameOver };
 
 class Window {
  public:

--- a/include/network/message.hpp
+++ b/include/network/message.hpp
@@ -29,6 +29,8 @@ enum class Type {
   UserStateUpdate,
   LobbyUpdate,
   LobbyPlayerUpdate,
+  LobbyReady,
+  GameLoaded,
   GameStart,
   JumpEvent,
   LandEvent,
@@ -164,6 +166,26 @@ struct LobbyUpdate {
   }
 };
 
+struct LobbyReady {
+  int _;
+
+  std::string to_string() const;
+  template <typename Archive>
+  void serialize(Archive& ar, unsigned int) {
+    ar& _;
+  }
+};
+
+struct GameLoaded {
+  int pid;
+
+  std::string to_string() const;
+  template <typename Archive>
+  void serialize(Archive& ar, unsigned int) {
+    ar& pid;
+  }
+};
+
 struct GameStart {
   std::unordered_map<int, bool> client_states;
 
@@ -227,10 +249,10 @@ struct GameOver {
 };
 
 struct Message {
-  using Body =
-      boost::variant<Assign, Greeting, Notify, GameStateUpdate, UserStateUpdate,
-                     LobbyUpdate, LobbyPlayerUpdate, GameStart, JumpEvent,
-                     LandEvent, ItemPickupEvent, TagEvent, GameOver>;
+  using Body = boost::variant<Assign, Greeting, Notify, GameStateUpdate,
+                              UserStateUpdate, LobbyUpdate, LobbyPlayerUpdate,
+                              LobbyReady, GameLoaded, GameStart, JumpEvent,
+                              LandEvent, ItemPickupEvent, TagEvent, GameOver>;
   Type type;
   Metadata metadata;
   Body body;

--- a/include/network/tcp_server.hpp
+++ b/include/network/tcp_server.hpp
@@ -24,7 +24,7 @@ class Server {
   Server(int port, AcceptHandler, CloseHandler, ReadHandler, WriteHandler,
          TickHandler);
 
-  void start_tick(int = 0);
+  void start_tick();
   void stop_tick();
   void write(const ClientID&, const message::Message&);
   void write_all(message::Message&);

--- a/include/network/tcp_server.hpp
+++ b/include/network/tcp_server.hpp
@@ -24,7 +24,7 @@ class Server {
   Server(int port, AcceptHandler, CloseHandler, ReadHandler, WriteHandler,
          TickHandler);
 
-  void start_tick();
+  void start_tick(int = 0);
   void stop_tick();
   void write(const ClientID&, const message::Message&);
   void write_all(message::Message&);

--- a/include/server/game.hpp
+++ b/include/server/game.hpp
@@ -38,6 +38,7 @@ class Game {
   void update(const message::UserStateUpdate&);
   void tick();
   void restart();
+  void update_start();
   std::vector<message::JumpEvent> get_jump_events();
   std::vector<message::LandEvent> get_land_events();
   std::vector<message::ItemPickupEvent> get_item_pickup_events();

--- a/include/server/manager.hpp
+++ b/include/server/manager.hpp
@@ -12,6 +12,7 @@ class Manager {
  public:
   enum class Status {
     Lobby,
+    GameLoading,
     InGame,
     GameOver,
   };
@@ -26,6 +27,8 @@ class Manager {
   message::LobbyUpdate handle_lobby_update(const message::LobbyPlayerUpdate&);
   message::LobbyUpdate get_lobby_update();
   bool check_ready();
+  void handle_game_loaded(const message::GameLoaded&);
+  bool check_loaded();
   void handle_game_update(const message::UserStateUpdate&);
   void tick_game();
   void start_game();
@@ -40,6 +43,7 @@ class Manager {
     int pid;
     std::string skin;
     bool is_ready;
+    bool is_loaded;
   };
 
   boost::asio::io_context io_context_;

--- a/include/server/manager.hpp
+++ b/include/server/manager.hpp
@@ -13,12 +13,14 @@ class Manager {
   enum class Status {
     Lobby,
     GameLoading,
+    GameCountdown,
     InGame,
     GameOver,
   };
 
   static std::size_t MAX_PLAYERS;
   static std::chrono::seconds TOTAL_GAME_DURATION;
+  static constexpr std::chrono::milliseconds COUNTDOWN_DURATION{3200};
 
   Manager();
 

--- a/src/client/graphics/Window.cpp
+++ b/src/client/graphics/Window.cpp
@@ -18,6 +18,7 @@
 #include <thread>
 
 #include "Camera.h"
+#include "GLFW/glfw3.h"
 #include "Input.h"
 #include "Scene.h"
 #include "config/lib.hpp"
@@ -155,8 +156,19 @@ GLFWwindow* Window::createWindow(int width, int height) {
 
   glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
   // Create the GLFW window.
+
+  // TODO(ann): pick the right one
+
+  /* maximize window */
+  // glfwWindowHint(GLFW_MAXIMIZED, GLFW_TRUE);
+
+  /* normal window */
   screenWindow = glfwCreateWindow(width, height, windowTitle, NULL, NULL);
   loadingWindow = glfwCreateWindow(1, 1, "Loader", NULL, screenWindow);
+
+  /* full screen window */
+  // GLFWwindow* window = glfwCreateWindow(width, height, windowTitle,
+  // glfwGetPrimaryMonitor(), NULL);
 
   // Check if the window could not be created.
   if (!screenWindow) {

--- a/src/client/graphics/Window.cpp
+++ b/src/client/graphics/Window.cpp
@@ -52,7 +52,7 @@ Scene* Window::gameScene;
 Load* Window::loadScreen;
 HUD* Window::hud;
 
-std::unique_ptr<Client> Window::client = nullptr;
+std::shared_ptr<Client> Window::client = nullptr;
 int Window::my_pid = -1;
 
 std::atomic<bool> Window::loading_resources{false};
@@ -264,9 +264,9 @@ void Window::update(GLFWwindow* window, float deltaTime) {
           std::ref(gameScene));
 
     } else if (dynamic_cast<Lobby*>(gameScene) &&
-               phase == GamePhase::Game) {  // lobby -> game
+               phase == GamePhase::GameLoading) {  // lobby -> game
       loading_resources = true;
-      remainingLoadBuffer = 10;
+      // remainingLoadBuffer = 10;
       auto lobby = dynamic_cast<Lobby*>(gameScene);
       std::map<int, message::LobbyPlayer> ps = lobby->players;
       gameScene = new Scene(Cam);
@@ -281,9 +281,9 @@ void Window::update(GLFWwindow* window, float deltaTime) {
             gameScene->init(lobby->players);
             hud->init();
             loading_resources = false;
-            Window::client->write<message::GameLoaded>(Window::my_pid);
+            client->write<message::GameLoaded>(my_pid);
           },
-          std::ref(gameScene), std::ref(hud), std::ref(lobby), Window::my_pid);
+          std::ref(gameScene), std::ref(hud), std::ref(lobby), my_pid);
     } else {
       gameScene->update(deltaTime);
     }

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -142,7 +142,7 @@ void network_init() {
   auto write_handler = [](std::size_t bytes_transferred,
                           const message::Message& m, Client& client) {};
 
-  Window::client = std::make_unique<Client>(server_addr, connect_handler,
+  Window::client = std::make_shared<Client>(server_addr, connect_handler,
                                             read_handler, write_handler);
 }
 

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -99,6 +99,10 @@ void network_init() {
       }
     };
 
+    auto lobby_ready_handler = [](const message::LobbyReady& body) {
+      Window::phase = GamePhase::GameLoading;
+    };
+
     auto game_start_handler = [](const message::GameStart& body) {
       Window::phase = GamePhase::Game;
     };
@@ -129,9 +133,9 @@ void network_init() {
 
     auto message_handler = boost::make_overloaded_function(
         assign_handler, game_state_update_handler, lobby_update_handler,
-        game_start_handler, jump_event_handler, land_event_handler,
-        item_pickup_event_handler, tag_event_handler, game_over_handler,
-        any_handler);
+        lobby_ready_handler, game_start_handler, jump_event_handler,
+        land_event_handler, item_pickup_event_handler, tag_event_handler,
+        game_over_handler, any_handler);
     boost::apply_visitor(message_handler, m.body);
   };
 

--- a/src/network/message.cpp
+++ b/src/network/message.cpp
@@ -52,6 +52,8 @@ Type get_type(const Message::Body& body) {
   auto lobby_player_update = [](const LobbyPlayerUpdate&) {
     return Type::LobbyPlayerUpdate;
   };
+  auto lobby_ready = [](const LobbyReady&) { return Type::LobbyReady; };
+  auto game_loaded = [](const GameLoaded&) { return Type::GameLoaded; };
   auto game_start = [](const GameStart&) { return Type::GameStart; };
   auto jump_event = [](const JumpEvent&) { return Type::JumpEvent; };
   auto land_event = [](const LandEvent&) { return Type::LandEvent; };
@@ -62,8 +64,8 @@ Type get_type(const Message::Body& body) {
   auto game_over = [](const GameOver&) { return Type::GameOver; };
   auto overload = boost::make_overloaded_function(
       assign, greeting, notify, game_state, user_state, lobby_update,
-      lobby_player_update, game_start, jump_event, land_event,
-      item_pickup_event, tag_event, game_over);
+      lobby_player_update, lobby_ready, game_loaded, game_start, jump_event,
+      land_event, item_pickup_event, tag_event, game_over);
   return boost::apply_visitor(overload, body);
 }
 
@@ -180,6 +182,14 @@ std::string LobbyUpdate::to_string() const {
   str += "    ]";
 
   return str;
+}
+
+std::string LobbyReady::to_string() const {
+  return "    all_clients_ready: true";
+}
+
+std::string GameLoaded::to_string() const {
+  return "    player " + std::to_string(pid) + " loaded: true";
 }
 
 std::string GameStart::to_string() const { return "    game_start: true"; }

--- a/src/network/tcp_server.cpp
+++ b/src/network/tcp_server.cpp
@@ -25,13 +25,9 @@ Server::Server(int port, AcceptHandler accept_handler,
   io_context_.run();
 }
 
-void Server::start_tick(int delay) {
-  // add delay for client countdown
-  timer_.expires_after(std::chrono::milliseconds{delay});
-  timer_.async_wait([this](const boost::system::error_code&) {
-    should_tick_ = true;
-    tick();
-  });
+void Server::start_tick() {
+  should_tick_ = true;
+  tick();
 }
 
 void Server::stop_tick() {

--- a/src/network/tcp_server.cpp
+++ b/src/network/tcp_server.cpp
@@ -2,7 +2,6 @@
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <chrono>
-#include <config/lib.hpp>
 #include <iostream>
 #include <memory>
 #include <network/message.hpp>
@@ -26,10 +25,9 @@ Server::Server(int port, AcceptHandler accept_handler,
   io_context_.run();
 }
 
-void Server::start_tick() {
-  auto config = get_config();
-  // delay game start for client loading
-  timer_.expires_from_now(std::chrono::seconds{config["game_start_delay"]});
+void Server::start_tick(int delay) {
+  // add delay for client countdown
+  timer_.expires_after(std::chrono::milliseconds{delay});
   timer_.async_wait([this](const boost::system::error_code&) {
     should_tick_ = true;
     tick();

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -6,5 +6,5 @@ set(_SERVER_SOURCES
     ${tagguys_SOURCE_DIR}/src/core/util/global.cpp)
 
 add_executable(server ${_SERVER_SOURCES})
-target_link_libraries(server PRIVATE core network config Boost::asio)
+target_link_libraries(server PRIVATE core network Boost::asio)
 target_include_directories(server PRIVATE ${tagguys_SOURCE_DIR}/include)

--- a/src/server/game.cpp
+++ b/src/server/game.cpp
@@ -115,6 +115,8 @@ void Game::restart() {
   start_time_ = std::chrono::steady_clock::now();
 }
 
+void Game::update_start() { start_time_ = std::chrono::steady_clock::now(); }
+
 std::vector<message::JumpEvent> Game::get_jump_events() {
   std::vector<message::JumpEvent> events;
   for (auto& e : jump_events_) events.push_back({get_pid(e.self)});

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -52,7 +52,6 @@ int main(int argc, char* argv[]) {
 
           // if all clients are ready, notify clients
           if (manager.check_ready()) {
-            manager.start_game();  // setup physics, don't tick yet
             server.write_all<message::LobbyReady>();
           }
         };
@@ -64,8 +63,8 @@ int main(int argc, char* argv[]) {
       // if all clients are loaded, start the game
       if (manager.check_loaded()) {
         server.write_all<message::GameStart>();
-        int COUNTDOWN_TIME = 3200;  // ms
-        server.start_tick(COUNTDOWN_TIME);
+        manager.start_game();  // initialize physics, start countdown
+        server.start_tick();   // start sending updates to clients
       }
     };
 
@@ -73,7 +72,7 @@ int main(int argc, char* argv[]) {
 
     auto message_handler = boost::make_overloaded_function(
         greeting_handler, user_state_update_handler,
-        lobby_player_update_handler, any_handler);
+        lobby_player_update_handler, game_loaded_handler, any_handler);
     boost::apply_visitor(message_handler, m.body);
   };
 

--- a/src/server/manager.cpp
+++ b/src/server/manager.cpp
@@ -20,7 +20,7 @@ Manager::Manager()
 int Manager::add_player() {
   int pid = game_->add_player();
   std::string default_skin = "trash panda";
-  players_.insert({pid, {pid, default_skin, false}});
+  players_.insert({pid, {pid, default_skin, false, false}});
 
   return pid;
 }
@@ -53,9 +53,24 @@ bool Manager::check_ready() {
     if (player.is_ready) ready_count++;
 
   bool is_ready = ready_count == MAX_PLAYERS;
-  if (is_ready) status_ = Status::InGame;
+  if (is_ready) status_ = Status::GameLoading;
 
   return is_ready;
+}
+
+void Manager::handle_game_loaded(const message::GameLoaded& body) {
+  players_.at(body.pid).is_loaded = true;
+}
+
+bool Manager::check_loaded() {
+  int loaded_count = 0;
+  for (auto& [_, player] : players_)
+    if (player.is_loaded) loaded_count++;
+
+  bool is_loaded = loaded_count == MAX_PLAYERS;
+  if (is_loaded) status_ = Status::InGame;
+
+  return is_loaded;
 }
 
 void Manager::handle_game_update(const message::UserStateUpdate& update) {

--- a/src/server/manager.cpp
+++ b/src/server/manager.cpp
@@ -90,6 +90,7 @@ void Manager::start_game() {
   timer_.expires_after(COUNTDOWN_DURATION);
   timer_.async_wait([this](const boost::system::error_code& _) {
     status_ = Status::InGame;
+    game_->update_start();
 
     // start game timer
     timer_.expires_after(TOTAL_GAME_DURATION);


### PR DESCRIPTION
This PR adds additional network synchronization for game loading and game countdown. Since the game takes quite a bit of time to load resources, we add extra messages to wait for all clients to load resources.

* Adds loading and countdown states on server
* Add new synchronization Messages
* Update client logic to fit this model 